### PR TITLE
[Fix] Agent/skills not calling each other before execution + Add install scripts as workaround for plugin source conflicts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "chip-design-architecture",
       "description": "Microarchitecture exploration, PPA estimation, risk assessment, and sign-off",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/architecture"],
       "agents": ["./agents/architecture-orchestrator.md"]
     },
@@ -21,7 +21,7 @@
       "name": "chip-design-rtl",
       "description": "SystemVerilog RTL design — module planning, coding standards, lint, CDC, synthesis check",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/rtl-design"],
       "agents": ["./agents/rtl-design-orchestrator.md"]
     },
@@ -29,7 +29,7 @@
       "name": "chip-design-verification",
       "description": "UVM testbench, test planning, constrained random, coverage closure, regression",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/functional-verification"],
       "agents": ["./agents/verification-orchestrator.md"]
     },
@@ -37,7 +37,7 @@
       "name": "chip-design-formal",
       "description": "Formal property verification (FPV) and logical equivalence checking (LEC)",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/formal-verification"],
       "agents": ["./agents/formal-orchestrator.md"]
     },
@@ -45,7 +45,7 @@
       "name": "chip-design-synthesis",
       "description": "Logic synthesis — SDC constraints, compile optimization, netlist QC and LEC",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/logic-synthesis"],
       "agents": ["./agents/synthesis-orchestrator.md"]
     },
@@ -53,7 +53,7 @@
       "name": "chip-design-dft",
       "description": "Design for Test — scan insertion, ATPG, MBIST, JTAG boundary scan",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/dft"],
       "agents": ["./agents/dft-orchestrator.md"]
     },
@@ -61,7 +61,7 @@
       "name": "chip-design-sta",
       "description": "Static timing analysis — multi-corner analysis, exception review, ECO guidance",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/sta"],
       "agents": ["./agents/sta-orchestrator.md"]
     },
@@ -69,7 +69,7 @@
       "name": "chip-design-hls",
       "description": "High-level synthesis — C/C++ to RTL, directive optimization, co-simulation",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/hls"],
       "agents": ["./agents/hls-orchestrator.md"]
     },
@@ -77,7 +77,7 @@
       "name": "chip-design-pd",
       "description": "Physical design — floorplan, placement, CTS, routing, timing/power/area opt, sign-off",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/physical-design"],
       "agents": ["./agents/physical-design-orchestrator.md"]
     },
@@ -85,7 +85,7 @@
       "name": "chip-design-soc",
       "description": "SoC IP integration — procurement, bus fabric, chip-level simulation",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/soc-integration"],
       "agents": ["./agents/soc-integration-orchestrator.md"]
     },
@@ -93,7 +93,7 @@
       "name": "chip-design-compiler",
       "description": "Compiler toolchain — LLVM/GCC backend, assembler, linker, runtime libs for custom ISA",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/compiler-toolchain"],
       "agents": ["./agents/compiler-orchestrator.md"]
     },
@@ -101,7 +101,7 @@
       "name": "chip-design-firmware",
       "description": "Embedded firmware — BSP, peripheral drivers, RTOS integration, validation",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/embedded-firmware"],
       "agents": ["./agents/firmware-orchestrator.md"]
     },
@@ -109,7 +109,7 @@
       "name": "chip-design-fpga",
       "description": "FPGA emulation — ASIC-to-FPGA adaptation, partitioning, bring-up, SW validation",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/fpga-emulation"],
       "agents": ["./agents/fpga-orchestrator.md"]
     }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Restart Claude Code after running — all 13 skills and agents will be active.
 If you prefer the built-in marketplace installer, add the marketplace once then
 install each plugin **one at a time** to avoid the race condition:
 
-```
+```text
 /plugin marketplace add github:chuanseng-ng/digital-chip-design-agents
 /plugin install chip-design-architecture@digital-chip-design-agents
 /plugin install chip-design-rtl@digital-chip-design-agents

--- a/README.md
+++ b/README.md
@@ -9,19 +9,43 @@
 
 ## Install
 
-**Step 1 — Register the marketplace** (once per machine):
+> **Note:** The Claude Code marketplace installer has a known race-condition bug on
+> Windows when multiple plugins share the same source repo. Use the install scripts
+> below — they bypass the installer and work reliably on all platforms.
+
+### Option A — Install script (recommended)
+
+**macOS / Linux / Git Bash:**
+```bash
+git clone https://github.com/chuanseng-ng/digital-chip-design-agents.git
+cd digital-chip-design-agents
+bash install.sh
+```
+
+**Windows (PowerShell):**
+```powershell
+git clone https://github.com/chuanseng-ng/digital-chip-design-agents.git
+cd digital-chip-design-agents
+.\install.ps1
+```
+
+Restart Claude Code after running — all 13 skills and agents will be active.
+
+### Option B — Marketplace (install plugins individually)
+
+If you prefer the built-in marketplace installer, add the marketplace once then
+install each plugin **one at a time** to avoid the race condition:
+
 ```
 /plugin marketplace add github:chuanseng-ng/digital-chip-design-agents
-```
-
-**Step 2 — Install a domain plugin**:
-```
-/plugin install chip-design-pd@digital-chip-design-agents
+/plugin install chip-design-architecture@digital-chip-design-agents
 /plugin install chip-design-rtl@digital-chip-design-agents
 /plugin install chip-design-verification@digital-chip-design-agents
+... (repeat for each plugin)
 ```
 
-**Step 3 — Use it** — just describe your task in natural language:
+### Usage — describe your task in natural language
+
 ```
 Run the RTL design flow for my AXI DMA controller block
 Analyse timing violations on this routed DEF and suggest ECOs

--- a/agents/compiler-orchestrator.md
+++ b/agents/compiler-orchestrator.md
@@ -30,6 +30,7 @@ isa_analysis → backend_dev → assembler_dev → linker_config → runtime_lib
 - miscompilation_count: 0
 
 ## Behaviour Rules
-1. Miscompilation (wrong output) = P0 blocker — root cause required before retry
+1. Read the compiler-toolchain skill before executing each stage
+2. Miscompilation (wrong output) = P0 blocker — root cause required before retry
 2. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
 3. Output: toolchain release package + validation report + ABI spec

--- a/agents/compiler-orchestrator.md
+++ b/agents/compiler-orchestrator.md
@@ -32,5 +32,5 @@ isa_analysis → backend_dev → assembler_dev → linker_config → runtime_lib
 ## Behaviour Rules
 1. Read the compiler-toolchain skill before executing each stage
 2. Miscompilation (wrong output) = P0 blocker — root cause required before retry
-2. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
-3. Output: toolchain release package + validation report + ABI spec
+3. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
+4. Output: toolchain release package + validation report + ABI spec

--- a/agents/dft-orchestrator.md
+++ b/agents/dft-orchestrator.md
@@ -29,6 +29,7 @@ dft_architecture → scan_insertion → atpg → bist_insertion → jtag_setup �
 - jtag_connectivity: pass
 
 ## Behaviour Rules
-1. Track fault_coverage in state across all ATPG iterations
+1. Read the dft skill before executing each stage
+2. Track fault_coverage in state across all ATPG iterations
 2. Do not proceed to dft_signoff until SAF coverage meets target
 3. Output: DFT netlist, .scandef, ATPG patterns, BSDL file

--- a/agents/dft-orchestrator.md
+++ b/agents/dft-orchestrator.md
@@ -31,5 +31,5 @@ dft_architecture → scan_insertion → atpg → bist_insertion → jtag_setup �
 ## Behaviour Rules
 1. Read the dft skill before executing each stage
 2. Track fault_coverage in state across all ATPG iterations
-2. Do not proceed to dft_signoff until SAF coverage meets target
-3. Output: DFT netlist, .scandef, ATPG patterns, BSDL file
+3. Do not proceed to dft_signoff until SAF coverage meets target
+4. Output: DFT netlist, .scandef, ATPG patterns, BSDL file

--- a/agents/firmware-orchestrator.md
+++ b/agents/firmware-orchestrator.md
@@ -29,6 +29,7 @@ bsp_development → peripheral_drivers → rtos_integration → driver_validatio
 - open_p0_bugs: 0
 
 ## Behaviour Rules
-1. Do not proceed to rtos_integration until ALL drivers pass unit tests
+1. Read the embedded-firmware skill before executing each stage
+2. Do not proceed to rtos_integration until ALL drivers pass unit tests
 2. Track drivers_complete[] in state — partial driver list blocks RTOS stage
 3. Output: validated firmware package + bring-up guide + known issues list

--- a/agents/firmware-orchestrator.md
+++ b/agents/firmware-orchestrator.md
@@ -31,5 +31,5 @@ bsp_development → peripheral_drivers → rtos_integration → driver_validatio
 ## Behaviour Rules
 1. Read the embedded-firmware skill before executing each stage
 2. Do not proceed to rtos_integration until ALL drivers pass unit tests
-2. Track drivers_complete[] in state — partial driver list blocks RTOS stage
-3. Output: validated firmware package + bring-up guide + known issues list
+3. Track drivers_complete[] in state — partial driver list blocks RTOS stage
+4. Output: validated firmware package + bring-up guide + known issues list

--- a/agents/formal-orchestrator.md
+++ b/agents/formal-orchestrator.md
@@ -30,5 +30,5 @@ property_planning → environment_setup → fpv_run → cex_analysis → lec_run
 ## Behaviour Rules
 1. Read the formal-verification skill before executing each stage
 2. CEX from RTL bug: suspend, report to RTL team, wait for fix confirmation before retry
-2. Flag any unproven P0 property as a hard blocker for sign-off
-3. Vacuity check required after every environment_setup iteration
+3. Flag any unproven P0 property as a hard blocker for sign-off
+4. Vacuity check required after every environment_setup iteration

--- a/agents/formal-orchestrator.md
+++ b/agents/formal-orchestrator.md
@@ -28,6 +28,7 @@ property_planning → environment_setup → fpv_run → cex_analysis → lec_run
 - vacuous_proofs: 0
 
 ## Behaviour Rules
-1. CEX from RTL bug: suspend, report to RTL team, wait for fix confirmation before retry
+1. Read the formal-verification skill before executing each stage
+2. CEX from RTL bug: suspend, report to RTL team, wait for fix confirmation before retry
 2. Flag any unproven P0 property as a hard blocker for sign-off
 3. Vacuity check required after every environment_setup iteration

--- a/agents/fpga-orchestrator.md
+++ b/agents/fpga-orchestrator.md
@@ -30,7 +30,8 @@ rtl_adaptation → partitioning → fpga_synthesis → bring_up → sw_validatio
 - hw_bugs_filed_to_rtl: true
 
 ## Behaviour Rules
-1. HW bugs found on prototype: file to RTL team with ILA capture evidence before retry
+1. Read the fpga-emulation skill before executing each stage
+2. HW bugs found on prototype: file to RTL team with ILA capture evidence before retry
 2. SW bugs: fix in firmware without re-synthesising unless HW root cause confirmed
 3. All performance measurements: record at prototype frequency with scale factor noted
 4. Output: prototype sign-off report + HW bug report for RTL team + performance baseline

--- a/agents/fpga-orchestrator.md
+++ b/agents/fpga-orchestrator.md
@@ -32,6 +32,6 @@ rtl_adaptation → partitioning → fpga_synthesis → bring_up → sw_validatio
 ## Behaviour Rules
 1. Read the fpga-emulation skill before executing each stage
 2. HW bugs found on prototype: file to RTL team with ILA capture evidence before retry
-2. SW bugs: fix in firmware without re-synthesising unless HW root cause confirmed
-3. All performance measurements: record at prototype frequency with scale factor noted
-4. Output: prototype sign-off report + HW bug report for RTL team + performance baseline
+3. SW bugs: fix in firmware without re-synthesising unless HW root cause confirmed
+4. All performance measurements: record at prototype frequency with scale factor noted
+5. Output: prototype sign-off report + HW bug report for RTL team + performance baseline

--- a/agents/hls-orchestrator.md
+++ b/agents/hls-orchestrator.md
@@ -33,5 +33,5 @@ algorithm_analysis → directive_planning → hls_synthesis → rtl_qc → cosim
 ## Behaviour Rules
 1. Read the hls skill before executing each stage
 2. Track hls_report metrics (latency, II, area) in state across iterations
-2. Co-simulation output mismatch is always a blocker — root cause before retry
-3. Output: HLS RTL package + co-sim report + interface documentation
+3. Co-simulation output mismatch is always a blocker — root cause before retry
+4. Output: HLS RTL package + co-sim report + interface documentation

--- a/agents/hls-orchestrator.md
+++ b/agents/hls-orchestrator.md
@@ -31,6 +31,7 @@ algorithm_analysis → directive_planning → hls_synthesis → rtl_qc → cosim
 - area_within_budget: true
 
 ## Behaviour Rules
-1. Track hls_report metrics (latency, II, area) in state across iterations
+1. Read the hls skill before executing each stage
+2. Track hls_report metrics (latency, II, area) in state across iterations
 2. Co-simulation output mismatch is always a blocker — root cause before retry
 3. Output: HLS RTL package + co-sim report + interface documentation

--- a/agents/physical-design-orchestrator.md
+++ b/agents/physical-design-orchestrator.md
@@ -38,5 +38,5 @@ floorplan → placement → cts → routing → timing_optimization → power_op
 ## Behaviour Rules
 1. Read the physical-design skill before executing each stage
 2. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
-2. Never proceed past a FAIL without applying the loop-back rule
-3. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report
+3. Never proceed past a FAIL without applying the loop-back rule
+4. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report

--- a/agents/physical-design-orchestrator.md
+++ b/agents/physical-design-orchestrator.md
@@ -36,6 +36,7 @@ floorplan → placement → cts → routing → timing_optimization → power_op
 - core_area_util_pct: <= 85
 
 ## Behaviour Rules
-1. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
+1. Read the physical-design skill before executing each stage
+2. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
 2. Never proceed past a FAIL without applying the loop-back rule
 3. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report

--- a/agents/soc-integration-orchestrator.md
+++ b/agents/soc-integration-orchestrator.md
@@ -32,5 +32,5 @@ ip_procurement → ip_configuration → bus_fabric_setup → top_integration →
 ## Behaviour Rules
 1. Read the soc-integration skill before executing each stage
 2. Block progression if any IP has unresolved qualification issues
-2. Track ip_status{} per IP in state — never proceed with unqualified IP
-3. Output: integrated SoC RTL package ready for synthesis
+3. Track ip_status{} per IP in state — never proceed with unqualified IP
+4. Output: integrated SoC RTL package ready for synthesis

--- a/agents/soc-integration-orchestrator.md
+++ b/agents/soc-integration-orchestrator.md
@@ -30,6 +30,7 @@ ip_procurement → ip_configuration → bus_fabric_setup → top_integration →
 - unqualified_ips: 0
 
 ## Behaviour Rules
-1. Block progression if any IP has unresolved qualification issues
+1. Read the soc-integration skill before executing each stage
+2. Block progression if any IP has unresolved qualification issues
 2. Track ip_status{} per IP in state — never proceed with unqualified IP
 3. Output: integrated SoC RTL package ready for synthesis

--- a/agents/sta-orchestrator.md
+++ b/agents/sta-orchestrator.md
@@ -30,6 +30,7 @@ constraint_validation → multi_corner_analysis → path_analysis → exception_
 - hold_tns_ps: == 0 (all corners)
 
 ## Behaviour Rules
-1. Run multi-corner before every ECO decision — never use single-corner results for ECO guidance
+1. Read the sta skill before executing each stage
+2. Run multi-corner before every ECO decision — never use single-corner results for ECO guidance
 2. LEC required after every ECO batch — do not accumulate ECOs without equivalence check
 3. ECO count > 2% of cells: hard stop, escalate to physical design team

--- a/agents/sta-orchestrator.md
+++ b/agents/sta-orchestrator.md
@@ -18,10 +18,11 @@ You are the STA Orchestrator.
 constraint_validation → multi_corner_analysis → path_analysis → exception_review → eco_guidance → sta_signoff
 
 ## Loop-Back Rules
-- path_analysis: violations found             → eco_guidance           (unlimited)
+- path_analysis: violations found             → exception_review       (unlimited)
+- exception_review: invalid exceptions       → path_analysis          (max 3×)
+- exception_review: all signed off           → eco_guidance
 - eco_guidance: ECO applied                  → multi_corner_analysis  (max 10× total)
 - eco_guidance: ECO cell count > 2%          → escalate to PD team
-- exception_review: invalid exceptions       → path_analysis          (max 3×)
 
 ## Sign-off Criteria
 - setup_wns_ns: >= 0 (all corners)
@@ -32,5 +33,6 @@ constraint_validation → multi_corner_analysis → path_analysis → exception_
 ## Behaviour Rules
 1. Read the sta skill before executing each stage
 2. Run multi-corner before every ECO decision — never use single-corner results for ECO guidance
-2. LEC required after every ECO batch — do not accumulate ECOs without equivalence check
-3. ECO count > 2% of cells: hard stop, escalate to physical design team
+3. LEC required after every ECO batch — do not accumulate ECOs without equivalence check
+4. ECO count > 2% of cells: hard stop, escalate to physical design team
+5. Do not enter eco_guidance if any exception in exception_review is pending sign-off — block until resolved

--- a/agents/verification-orchestrator.md
+++ b/agents/verification-orchestrator.md
@@ -32,5 +32,5 @@ tb_architecture → test_planning → uvm_tb_build → directed_tests → constr
 ## Behaviour Rules
 1. Read the functional-verification skill before executing each stage
 2. Track all bugs in state bugs_found[] — do not discard between stages
-2. Do not proceed to regression_signoff if any P0/P1 bugs remain open
-3. Bug found during directed tests: suspend flow; present RTL fix required report
+3. Do not proceed to regression_signoff if any P0/P1 bugs remain open
+4. Bug found during directed tests: suspend flow; present RTL fix required report

--- a/agents/verification-orchestrator.md
+++ b/agents/verification-orchestrator.md
@@ -30,6 +30,7 @@ tb_architecture → test_planning → uvm_tb_build → directed_tests → constr
 - uvm_fatal_count: 0
 
 ## Behaviour Rules
-1. Track all bugs in state bugs_found[] — do not discard between stages
+1. Read the functional-verification skill before executing each stage
+2. Track all bugs in state bugs_found[] — do not discard between stages
 2. Do not proceed to regression_signoff if any P0/P1 bugs remain open
 3. Bug found during directed tests: suspend flow; present RTL fix required report

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,114 @@
+# install.ps1 — sets up all 13 digital-chip-design-agents plugins for Claude Code
+# Run from the repo root in PowerShell:  .\install.ps1
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RepoDir    = $PSScriptRoot
+$Marketplace = "digital-chip-design-agents"
+$Version    = "1.0.0"
+
+# ── Locate Claude config dir ──────────────────────────────────────────────────
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) {
+    $env:CLAUDE_CONFIG_DIR
+} else {
+    Join-Path $env:USERPROFILE ".claude"
+}
+
+$CacheDir = Join-Path $ClaudeDir "plugins\cache\$Marketplace"
+$Settings = Join-Path $ClaudeDir "settings.json"
+
+Write-Host "Claude config : $ClaudeDir"
+Write-Host "Plugin cache  : $CacheDir"
+Write-Host ""
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+if (-not (Test-Path $ClaudeDir)) {
+    Write-Error "Claude config directory not found at '$ClaudeDir'.`nMake sure Claude Code is installed and has been run at least once."
+    exit 1
+}
+
+if (-not (Test-Path (Join-Path $RepoDir ".claude-plugin\marketplace.json"))) {
+    Write-Error "Run this script from the repo root."
+    exit 1
+}
+
+# ── Plugin list ───────────────────────────────────────────────────────────────
+$Plugins = @(
+    "chip-design-architecture",  "chip-design-rtl",
+    "chip-design-verification",  "chip-design-formal",
+    "chip-design-synthesis",     "chip-design-dft",
+    "chip-design-sta",           "chip-design-hls",
+    "chip-design-pd",            "chip-design-soc",
+    "chip-design-compiler",      "chip-design-firmware",
+    "chip-design-fpga"
+)
+
+# ── Populate plugin cache ─────────────────────────────────────────────────────
+Write-Host "Installing plugin cache..."
+foreach ($Plugin in $Plugins) {
+    $Dest = Join-Path $CacheDir "$Plugin\$Version"
+
+    if (Test-Path $Dest) { Remove-Item $Dest -Recurse -Force }
+    New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+
+    Copy-Item (Join-Path $RepoDir "agents") $Dest -Recurse -Force
+    Copy-Item (Join-Path $RepoDir "skills") $Dest -Recurse -Force
+
+    $Docs = Join-Path $RepoDir "docs"
+    if (Test-Path $Docs) { Copy-Item $Docs $Dest -Recurse -Force }
+
+    $Readme = Join-Path $RepoDir "README.md"
+    if (Test-Path $Readme) { Copy-Item $Readme $Dest -Force }
+
+    $License = Join-Path $RepoDir "LICENSE"
+    if (Test-Path $License) { Copy-Item $License $Dest -Force }
+
+    Write-Host "  [OK] $Plugin"
+}
+
+# ── Update settings.json ──────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "Updating $Settings ..."
+
+$Cfg = if (Test-Path $Settings) {
+    Get-Content $Settings -Raw | ConvertFrom-Json
+} else {
+    [PSCustomObject]@{}
+}
+
+# Ensure enabledPlugins exists
+if (-not ($Cfg.PSObject.Properties.Name -contains "enabledPlugins")) {
+    $Cfg | Add-Member -MemberType NoteProperty -Name "enabledPlugins" -Value ([PSCustomObject]@{})
+}
+foreach ($Plugin in $Plugins) {
+    $Key = "${Plugin}@${Marketplace}"
+    if (-not ($Cfg.enabledPlugins.PSObject.Properties.Name -contains $Key)) {
+        $Cfg.enabledPlugins | Add-Member -MemberType NoteProperty -Name $Key -Value $true
+    } else {
+        $Cfg.enabledPlugins.$Key = $true
+    }
+}
+
+# Ensure extraKnownMarketplaces exists
+if (-not ($Cfg.PSObject.Properties.Name -contains "extraKnownMarketplaces")) {
+    $Cfg | Add-Member -MemberType NoteProperty -Name "extraKnownMarketplaces" -Value ([PSCustomObject]@{})
+}
+# Always overwrite the marketplace source so it points to the current clone location
+$MarketplaceSource = [PSCustomObject]@{
+    source = [PSCustomObject]@{
+        source = "directory"
+        path   = $RepoDir
+    }
+}
+if ($Cfg.extraKnownMarketplaces.PSObject.Properties.Name -contains $Marketplace) {
+    $Cfg.extraKnownMarketplaces.$Marketplace = $MarketplaceSource
+} else {
+    $Cfg.extraKnownMarketplaces | Add-Member -MemberType NoteProperty -Name $Marketplace -Value $MarketplaceSource
+}
+
+$Cfg | ConvertTo-Json -Depth 10 | Set-Content $Settings -Encoding UTF8
+Write-Host "  [OK] $($Plugins.Count) plugins enabled in settings.json"
+
+Write-Host ""
+Write-Host "Done! Restart Claude Code to activate all 13 plugins."

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# install.ps1 — sets up all 13 digital-chip-design-agents plugins for Claude Code
+# install.ps1 - sets up all 13 digital-chip-design-agents plugins for Claude Code
 # Run from the repo root in PowerShell:  .\install.ps1
 #Requires -Version 5.1
 Set-StrictMode -Version Latest

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ VERSION="1.0.0"
 # ── Locate Claude config dir ──────────────────────────────────────────────────
 if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
   CLAUDE_DIR="$CLAUDE_CONFIG_DIR"
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+elif [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OSTYPE" == win32* ]]; then
   CLAUDE_DIR="${USERPROFILE}/.claude"
 else
   CLAUDE_DIR="${HOME}/.claude"
@@ -76,6 +76,13 @@ for plugin in "${PLUGINS[@]}"; do
   ENABLED_JSON+="    \"${plugin}@${MARKETPLACE}\": true,"$'\n'
 done
 ENABLED_JSON="${ENABLED_JSON%,$'\n'}"  # strip trailing comma
+
+# Preflight: python3 required for JSON merge
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required but not found in PATH."
+  echo "  Install Python 3 and re-run this script."
+  exit 1
+fi
 
 # Use Python for safe JSON merge (handles missing/existing settings)
 python3 - "$SETTINGS" "$MARKETPLACE" "$REPO_DIR" <<PYEOF

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# install.sh — sets up all 13 digital-chip-design-agents plugins for Claude Code
+# Works on macOS, Linux, and Git Bash / MSYS2 on Windows.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MARKETPLACE="digital-chip-design-agents"
+VERSION="1.0.0"
+
+# ── Locate Claude config dir ──────────────────────────────────────────────────
+if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+  CLAUDE_DIR="$CLAUDE_CONFIG_DIR"
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+  CLAUDE_DIR="${USERPROFILE}/.claude"
+else
+  CLAUDE_DIR="${HOME}/.claude"
+fi
+
+CACHE_DIR="$CLAUDE_DIR/plugins/cache/$MARKETPLACE"
+SETTINGS="$CLAUDE_DIR/settings.json"
+
+echo "Claude config : $CLAUDE_DIR"
+echo "Plugin cache  : $CACHE_DIR"
+echo ""
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+if [[ ! -d "$CLAUDE_DIR" ]]; then
+  echo "ERROR: Claude config directory not found at $CLAUDE_DIR"
+  echo "  Make sure Claude Code is installed and has been run at least once."
+  exit 1
+fi
+
+if [[ ! -f "$REPO_DIR/.claude-plugin/marketplace.json" ]]; then
+  echo "ERROR: Run this script from the repo root."
+  exit 1
+fi
+
+# ── Plugin list ───────────────────────────────────────────────────────────────
+PLUGINS=(
+  "chip-design-architecture"
+  "chip-design-rtl"
+  "chip-design-verification"
+  "chip-design-formal"
+  "chip-design-synthesis"
+  "chip-design-dft"
+  "chip-design-sta"
+  "chip-design-hls"
+  "chip-design-pd"
+  "chip-design-soc"
+  "chip-design-compiler"
+  "chip-design-firmware"
+  "chip-design-fpga"
+)
+
+# ── Populate plugin cache ─────────────────────────────────────────────────────
+echo "Installing plugin cache..."
+for plugin in "${PLUGINS[@]}"; do
+  dest="$CACHE_DIR/$plugin/$VERSION"
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -r "$REPO_DIR/agents" "$dest/"
+  cp -r "$REPO_DIR/skills" "$dest/"
+  [[ -d "$REPO_DIR/docs" ]]      && cp -r "$REPO_DIR/docs"      "$dest/"
+  [[ -f "$REPO_DIR/README.md" ]] && cp    "$REPO_DIR/README.md" "$dest/"
+  [[ -f "$REPO_DIR/LICENSE" ]]   && cp    "$REPO_DIR/LICENSE"   "$dest/"
+  echo "  [OK] $plugin"
+done
+
+# ── Update settings.json ──────────────────────────────────────────────────────
+echo ""
+echo "Updating $SETTINGS ..."
+
+# Build the enabled-plugins JSON block
+ENABLED_JSON=""
+for plugin in "${PLUGINS[@]}"; do
+  ENABLED_JSON+="    \"${plugin}@${MARKETPLACE}\": true,"$'\n'
+done
+ENABLED_JSON="${ENABLED_JSON%,$'\n'}"  # strip trailing comma
+
+# Use Python for safe JSON merge (handles missing/existing settings)
+python3 - "$SETTINGS" "$MARKETPLACE" "$REPO_DIR" <<PYEOF
+import json, sys, os
+
+settings_path = sys.argv[1]
+marketplace   = sys.argv[2]
+
+plugins = [
+  "chip-design-architecture", "chip-design-rtl", "chip-design-verification",
+  "chip-design-formal",       "chip-design-synthesis", "chip-design-dft",
+  "chip-design-sta",          "chip-design-hls",       "chip-design-pd",
+  "chip-design-soc",          "chip-design-compiler",  "chip-design-firmware",
+  "chip-design-fpga",
+]
+
+cfg = {}
+if os.path.exists(settings_path):
+    with open(settings_path) as f:
+        cfg = json.load(f)
+
+enabled = cfg.setdefault("enabledPlugins", {})
+for p in plugins:
+    enabled[f"{p}@{marketplace}"] = True
+
+mp = cfg.setdefault("extraKnownMarketplaces", {})
+mp[marketplace] = {
+    "source": {"source": "directory", "path": sys.argv[3]}
+}
+
+with open(settings_path, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+
+print(f"  [OK] {len(plugins)} plugins enabled in settings.json")
+PYEOF
+
+echo ""
+echo "Done! Restart Claude Code to activate all 13 plugins."

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Architecture Evaluation
 
+## Invocation
+
+When this skill is loaded and a user presents a design task, **do not execute
+stages directly**. Immediately spawn the
+`digital-chip-design-agents:architecture-orchestrator` agent and pass the full
+user request and any available context to it. The orchestrator enforces the
+stage sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide the full microarchitecture evaluation process from product specification
 through to a signed-off microarchitecture document ready for RTL handoff. Covers

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents a design task, **do not execute
-stages directly**. Immediately spawn the
-`digital-chip-design-agents:architecture-orchestrator` agent and pass the full
-user request and any available context to it. The orchestrator enforces the
-stage sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting a design task: immediately spawn the
+  `digital-chip-design-agents:architecture-orchestrator` agent and pass the full
+  user request and any available context. Do not execute stages directly.
+- **If invoked by the `architecture-orchestrator` mid-flow**: do not spawn a new
+  agent. Treat this file as read-only — return the requested stage rules,
+  sign-off criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Guide the full microarchitecture evaluation process from product specification

--- a/skills/compiler-toolchain/SKILL.md
+++ b/skills/compiler-toolchain/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Compiler Toolchain Development
 
+## Invocation
+
+When this skill is loaded and a user presents a compiler or ISA task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:compiler-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Build and validate a complete compiler toolchain (LLVM or GCC based) for a
 custom processor ISA. Bridges hardware and software — without a working

--- a/skills/dft/SKILL.md
+++ b/skills/dft/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents a DFT task, **do not execute
-stages directly**. Immediately spawn the
-`digital-chip-design-agents:dft-orchestrator` agent and pass the full user
-request and any available context to it. The orchestrator enforces the stage
-sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting a DFT task: immediately spawn the
+  `digital-chip-design-agents:dft-orchestrator` agent and pass the full user
+  request and any available context. Do not execute stages directly.
+- **If invoked by the `dft-orchestrator` mid-flow**: do not spawn a new agent.
+  Treat this file as read-only — return the requested stage rules, sign-off
+  criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Guide the complete DFT flow from architecture planning through ATPG pattern

--- a/skills/dft/SKILL.md
+++ b/skills/dft/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Design for Test (DFT)
 
+## Invocation
+
+When this skill is loaded and a user presents a DFT task, **do not execute
+stages directly**. Immediately spawn the
+`digital-chip-design-agents:dft-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide the complete DFT flow from architecture planning through ATPG pattern
 generation, BIST insertion, JTAG setup, and sign-off. Ensures the manufactured

--- a/skills/embedded-firmware/SKILL.md
+++ b/skills/embedded-firmware/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Embedded Firmware & Device Drivers
 
+## Invocation
+
+When this skill is loaded and a user presents a firmware or BSP task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:firmware-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide BSP creation, peripheral driver development, RTOS integration, and
 system-level firmware validation. The firmware layer is the first software

--- a/skills/formal-verification/SKILL.md
+++ b/skills/formal-verification/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Formal Verification (FPV + LEC)
 
+## Invocation
+
+When this skill is loaded and a user presents a formal verification task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:formal-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Exhaustively prove design properties and equivalence using formal methods.
 Complements simulation-based verification for correctness proofs, protocol

--- a/skills/fpga-emulation/SKILL.md
+++ b/skills/fpga-emulation/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: FPGA Emulation & Prototyping
 
+## Invocation
+
+When this skill is loaded and a user presents an FPGA prototyping task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:fpga-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Port an ASIC design to an FPGA prototype platform for pre-silicon hardware/
 software co-development. The FPGA prototype is not cycle-accurate but

--- a/skills/fpga-emulation/SKILL.md
+++ b/skills/fpga-emulation/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents an FPGA prototyping task, **do not
-execute stages directly**. Immediately spawn the
-`digital-chip-design-agents:fpga-orchestrator` agent and pass the full user
-request and any available context to it. The orchestrator enforces the stage
-sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting an FPGA prototyping task: immediately spawn
+  the `digital-chip-design-agents:fpga-orchestrator` agent and pass the full user
+  request and any available context. Do not execute stages directly.
+- **If invoked by the `fpga-orchestrator` mid-flow**: do not spawn a new agent.
+  Treat this file as read-only — return the requested stage rules, sign-off
+  criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Port an ASIC design to an FPGA prototype platform for pre-silicon hardware/

--- a/skills/functional-verification/SKILL.md
+++ b/skills/functional-verification/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Functional Verification (UVM)
 
+## Invocation
+
+When this skill is loaded and a user presents a verification task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:verification-orchestrator` agent and pass the full
+user request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide the complete UVM functional verification flow from testbench architecture
 through coverage-closed regression sign-off. Produces a verified RTL package
@@ -121,6 +133,53 @@ priority:     P0
 - UVM component source files
 - SVA assertion files (bind-based)
 - Compile script
+
+---
+
+## Stage: directed_tests
+
+### Domain Rules
+1. Implement one directed test per V-plan entry — tests must be deterministic
+2. Each test: verify the exact functional requirement it targets (no catch-all tests)
+3. Error/exception paths: explicit stimulus to trigger each one
+4. Corner cases: boundary values, max/min, overflow, underflow — one test each
+5. Reset during active transaction: at least one test per interface
+6. P0 tests must all pass before constrained-random phase begins
+7. DUT bug found during directed test: **suspend flow immediately** — do not continue
+   to constrained-random; flag RTL fix required and wait for confirmation
+
+### QoR Metrics to Evaluate
+- All V-plan features covered by at least one directed test
+- P0 directed tests: 100% pass before proceeding
+- 0 UVM FATAL or ERROR during directed test phase
+
+### Output Required
+- Directed test source files (one UVM sequence per feature)
+- Directed test pass/fail report
+- Bug report (if any DUT bugs found)
+
+---
+
+## Stage: constrained_random
+
+### Domain Rules
+1. Constraint blocks: randomise all stimulus fields within protocol-legal ranges
+2. Bias constraints: weight toward uncovered coverage bins identified in prior runs
+3. Seeds: use at least 10 distinct seeds before evaluating coverage
+4. Scoreboards active throughout: every transaction checked against reference model
+5. Any UVM FATAL: stop immediately — do not accumulate errors across seeds
+6. Any scoreboard mismatch: classify as DUT bug or testbench bug before continuing
+7. Run until coverage targets are met or max seed budget exhausted
+
+### QoR Metrics to Evaluate
+- Functional coverage: trending toward 100% across seeds
+- No persistent scoreboard mismatches (classify and fix before more seeds)
+- Regression pass rate: 100% (no failing seeds)
+
+### Output Required
+- Coverage report (merged across all seeds run so far)
+- Uncovered bin list for directed test closure
+- Seed log (seed number, pass/fail, coverage achieved)
 
 ---
 

--- a/skills/hls/SKILL.md
+++ b/skills/hls/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: High-Level Synthesis (HLS)
 
+## Invocation
+
+When this skill is loaded and a user presents an HLS task, **do not execute
+stages directly**. Immediately spawn the
+`digital-chip-design-agents:hls-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Convert C/C++/SystemC algorithmic descriptions to synthesisable RTL.
 Covers algorithm analysis for HLS compatibility, pragma/directive optimisation,

--- a/skills/hls/SKILL.md
+++ b/skills/hls/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents an HLS task, **do not execute
-stages directly**. Immediately spawn the
-`digital-chip-design-agents:hls-orchestrator` agent and pass the full user
-request and any available context to it. The orchestrator enforces the stage
-sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting an HLS task: immediately spawn the
+  `digital-chip-design-agents:hls-orchestrator` agent and pass the full user
+  request and any available context. Do not execute stages directly.
+- **If invoked by the `hls-orchestrator` mid-flow**: do not spawn a new agent.
+  Treat this file as read-only — return the requested stage rules, sign-off
+  criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Convert C/C++/SystemC algorithmic descriptions to synthesisable RTL.

--- a/skills/logic-synthesis/SKILL.md
+++ b/skills/logic-synthesis/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents a synthesis task, **do not execute
-stages directly**. Immediately spawn the
-`digital-chip-design-agents:synthesis-orchestrator` agent and pass the full user
-request and any available context to it. The orchestrator enforces the stage
-sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting a synthesis task: immediately spawn the
+  `digital-chip-design-agents:synthesis-orchestrator` agent and pass the full
+  user request and any available context. Do not execute stages directly.
+- **If invoked by the `synthesis-orchestrator` mid-flow**: do not spawn a new
+  agent. Treat this file as read-only — return the requested stage rules,
+  sign-off criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Produce a timing-clean, area-efficient, LEC-verified gate-level netlist

--- a/skills/logic-synthesis/SKILL.md
+++ b/skills/logic-synthesis/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Logic Synthesis
 
+## Invocation
+
+When this skill is loaded and a user presents a synthesis task, **do not execute
+stages directly**. Immediately spawn the
+`digital-chip-design-agents:synthesis-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Produce a timing-clean, area-efficient, LEC-verified gate-level netlist
 from RTL. Covers constraint setup, synthesis compilation strategy, and

--- a/skills/physical-design/SKILL.md
+++ b/skills/physical-design/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Physical Design
 
+## Invocation
+
+When this skill is loaded and a user presents a physical design task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:physical-design-orchestrator` agent and pass the full
+user request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide the complete physical implementation flow from gate-level netlist to
 tape-out-ready GDS-II. Eight stages with explicit QoR gates and loop-back

--- a/skills/physical-design/SKILL.md
+++ b/skills/physical-design/SKILL.md
@@ -15,15 +15,15 @@ allowed-tools: Read, Write, Bash
 
 ## Invocation
 
-When this skill is loaded and a user presents a physical design task, **do not
-execute stages directly**. Immediately spawn the
-`digital-chip-design-agents:physical-design-orchestrator` agent and pass the full
-user request and any available context to it. The orchestrator enforces the stage
-sequence, loop-back rules, and sign-off criteria defined below.
+- **If invoked by a user** presenting a physical design task: immediately spawn
+  the `digital-chip-design-agents:physical-design-orchestrator` agent and pass
+  the full user request and any available context. Do not execute stages directly.
+- **If invoked by the `physical-design-orchestrator` mid-flow**: do not spawn a
+  new agent. Treat this file as read-only — return the requested stage rules,
+  sign-off criteria, or loop-back guidance to the calling orchestrator.
 
-Use the domain rules in this file only when the orchestrator reads this skill
-mid-flow for stage-specific guidance, or when the user asks a targeted reference
-question rather than requesting a full flow execution.
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
 
 ## Purpose
 Guide the complete physical implementation flow from gate-level netlist to

--- a/skills/rtl-design/SKILL.md
+++ b/skills/rtl-design/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: RTL Design (SystemVerilog)
 
+## Invocation
+
+When this skill is loaded and a user presents an RTL design task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:rtl-design-orchestrator` agent and pass the full
+user request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Guide RTL development from module hierarchy planning through lint-clean,
 CDC-clean, synthesis-ready RTL. Enforces industry-standard SystemVerilog

--- a/skills/soc-integration/SKILL.md
+++ b/skills/soc-integration/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: SoC IP Integration
 
+## Invocation
+
+When this skill is loaded and a user presents a SoC integration task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:soc-integration-orchestrator` agent and pass the full
+user request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Assemble a complete SoC from first-party RTL, licensed hard/soft IPs, and
 memory macros. Covers IP procurement, bus fabric configuration, top-level

--- a/skills/sta/SKILL.md
+++ b/skills/sta/SKILL.md
@@ -126,6 +126,7 @@ and timing sign-off. WNS ≥ 0 and TNS = 0 at all corners required for tape-out.
 5. Post-ECO exceptions: verify any new exceptions added after ECO are still valid
 
 ### Common Exception Errors
+
 | Error | Consequence |
 |-------|------------|
 | `set_false_path` on functional CDC | Real metastability risk hidden |

--- a/skills/sta/SKILL.md
+++ b/skills/sta/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools: Read, Write, Bash
 
 # Skill: Static Timing Analysis (STA)
 
+## Invocation
+
+When this skill is loaded and a user presents a timing analysis task, **do not
+execute stages directly**. Immediately spawn the
+`digital-chip-design-agents:sta-orchestrator` agent and pass the full user
+request and any available context to it. The orchestrator enforces the stage
+sequence, loop-back rules, and sign-off criteria defined below.
+
+Use the domain rules in this file only when the orchestrator reads this skill
+mid-flow for stage-specific guidance, or when the user asks a targeted reference
+question rather than requesting a full flow execution.
+
 ## Purpose
 Multi-corner, multi-mode timing analysis, exception review, ECO-guided closure,
 and timing sign-off. WNS ≥ 0 and TNS = 0 at all corners required for tape-out.
@@ -98,6 +110,38 @@ and timing sign-off. WNS ≥ 0 and TNS = 0 at all corners required for tape-out.
 ### Output Required
 - Failing path analysis (root cause per path group)
 - Paths requiring ECO vs paths requiring SDC correction
+
+---
+
+## Stage: exception_review
+
+### Domain Rules
+1. Review every timing exception for correctness and scope:
+   - `set_false_path`: verify the path is truly non-functional (not just inconvenient)
+   - `set_multicycle_path`: verify both `-setup N` and `-hold 1` are set correctly
+   - `set_max_delay`: verify value matches system-level timing budget
+2. Overly broad exceptions: any exception matching > 1% of all paths requires architect approval
+3. Exceptions masking real violations: revoke immediately and re-run path analysis
+4. Every exception must have a documented justification (design intent, async crossing, test mode)
+5. Post-ECO exceptions: verify any new exceptions added after ECO are still valid
+
+### Common Exception Errors
+| Error | Consequence |
+|-------|------------|
+| `set_false_path` on functional CDC | Real metastability risk hidden |
+| MCP without hold correction | Hold violations introduced silently |
+| Exception too broad (glob match) | Unintended paths unconstrained |
+| Expired exception (removed logic) | Stale SDC — may mask other issues |
+
+### QoR Metrics to Evaluate
+- 0 exceptions without documented justification
+- 0 overly broad exceptions (flagged for architect review)
+- Exception list reviewed and signed off before ECO guidance begins
+
+### Output Required
+- Exception audit report (valid / revoked / needs-approval per exception)
+- Revised SDC with invalid exceptions removed
+- Exception sign-off record
 
 ---
 


### PR DESCRIPTION
- Agents & Skills not calling each other before execution
  - Update files to explicitly detail this relationship
- Add install scripts to workaround plugin source race issue
  - Restructure plugin structure in later release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-specific installers for Windows and macOS/Linux to set up the plugin marketplace and enable plugins.
  * Enabled strict execution mode for all 13 chip-design plugins.
  * Added a new exception-review stage for timing validation and formal exception auditing.
  * Verification skill enhanced with directed-test and constrained-random testing sections.

* **Documentation**
  * Revised installation instructions with two setup options and restart guidance.
  * Clarified that skills delegate to orchestrator agents and added orchestrator pre-read behavior rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->