### PR TITLE
[Feature] Add chip-design-infrastructure as 14th plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "github": "chuanseng-ng"
   },
   "metadata": {
-    "description": "Full digital chip design pipeline — 13 domains from architecture through tape-out and firmware.",
+    "description": "Full digital chip design pipeline — 14 domains from infrastructure setup through tape-out and firmware.",
     "version": "1.2.0"
   },
   "plugins": [
@@ -112,6 +112,14 @@
       "strict": true,
       "skills": ["./skills/fpga-emulation"],
       "agents": ["./agents/fpga-orchestrator.md"]
+    },
+    {
+      "name": "chip-design-infrastructure",
+      "description": "EDA tool detection, output-filtering shell wrappers, and MCP server config templates for all chip-design domain agents",
+      "source": "./plugins/infrastructure",
+      "strict": true,
+      "skills": ["./skills/infrastructure"],
+      "agents": ["./agents/infrastructure-orchestrator.md"]
     }
   ]
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,8 +128,8 @@ jobs:
           mp = json.load(open(".claude-plugin/marketplace.json"))
           mp_count = len(mp.get("plugins", []))
           print(f"Skills: {skill_count} | Agents: {agent_count} | Marketplace entries: {mp_count}")
-          assert skill_count == agent_count == mp_count == 13, \
-              f"Count mismatch — expected 13 each: skills={skill_count}, agents={agent_count}, marketplace={mp_count}"
+          assert skill_count == agent_count == mp_count == 14, \
+              f"Count mismatch — expected 14 each: skills={skill_count}, agents={agent_count}, marketplace={mp_count}"
           print("Count check PASSED")
           PYEOF
 
@@ -140,14 +140,14 @@ jobs:
 
           errors = []
 
-          # applyto-map.json must have all 13 domains
+          # applyto-map.json must have all 14 domains
           applyto_path = "ides/copilot/applyto-map.json"
           if not os.path.isfile(applyto_path):
               errors.append(f"Missing: {applyto_path}")
           else:
               applyto = json.load(open(applyto_path))
-              if len(applyto) != 13:
-                  errors.append(f"{applyto_path}: expected 13 domains, got {len(applyto)}")
+              if len(applyto) != 14:
+                  errors.append(f"{applyto_path}: expected 14 domains, got {len(applyto)}")
               else:
                   print(f"OK: {applyto_path} — {len(applyto)} domains")
 

--- a/docs/MASTER_INDEX.md
+++ b/docs/MASTER_INDEX.md
@@ -9,6 +9,11 @@
 
 ```
                      ┌─────────────────────────────────────────────────────┐
+                     │          0. INFRASTRUCTURE SETUP                    │
+                     │  Tool detection, wrappers, MCP config               │
+                     └────────────────────┬────────────────────────────────┘
+                                          │
+                     ┌────────────────────▼────────────────────────────────┐
                      │             PRODUCT SPECIFICATION                   │
                      └────────────────────┬────────────────────────────────┘
                                           │
@@ -68,6 +73,7 @@
 
 | # | Document | Description | Input | Output |
 |---|----------|-------------|-------|--------|
+| 0 | `Infrastructure_Setup_Flow.md` | EDA tool detection, wrapper deployment, MCP config | Host environment | tool-manifest.json, wrappers, MCP snippets |
 | 1 | `Architecture_Evaluation_Flow.md` | Microarch exploration, PPA estimate, risk | Product spec | Microarch doc |
 | 2 | `RTL_Design_Flow.md` | SV RTL coding, lint, CDC, synth check | Microarch doc | Synthesis-ready RTL |
 | 3 | `HLS_Flow.md` | C/C++ to RTL for algorithm blocks | C source + TB | Verified RTL |
@@ -301,4 +307,4 @@ All agents in this system share these configurations:
 └── sv-fpga-sw-validation/SKILL.md
 ```
 
-**Total: 12 Orchestrators | 13 Flow Documents | 48 Skill Files**
+**Total: 13 Orchestrators | 14 Flow Documents | 49 Skill Files**

--- a/ides/copilot/applyto-map.json
+++ b/ides/copilot/applyto-map.json
@@ -12,5 +12,5 @@
   "compiler":      "**/compiler/**,**/*.ll,**/*.td,**/llvm/**",
   "firmware":      "**/firmware/**,**/bsp/**,**/hal/**,**/rtos/**",
   "fpga":          "**/fpga/**,**/*.xdc,**/*.qsf,**/*.xpr,**/*.bit",
-  "infrastructure": "**/*"
+  "infrastructure": "**/infrastructure/**,plugins/infrastructure/**"
 }

--- a/ides/copilot/applyto-map.json
+++ b/ides/copilot/applyto-map.json
@@ -11,5 +11,6 @@
   "soc":           "**/soc/**,**/ip/**,**/*integration*,**/*fabric*",
   "compiler":      "**/compiler/**,**/*.ll,**/*.td,**/llvm/**",
   "firmware":      "**/firmware/**,**/bsp/**,**/hal/**,**/rtos/**",
-  "fpga":          "**/fpga/**,**/*.xdc,**/*.qsf,**/*.xpr,**/*.bit"
+  "fpga":          "**/fpga/**,**/*.xdc,**/*.qsf,**/*.xpr,**/*.bit",
+  "infrastructure": "**/*"
 }

--- a/install.ps1
+++ b/install.ps1
@@ -49,7 +49,7 @@ $Plugins = @(
     "chip-design-sta",           "chip-design-hls",
     "chip-design-pd",            "chip-design-soc",
     "chip-design-compiler",      "chip-design-firmware",
-    "chip-design-fpga"
+    "chip-design-fpga",          "chip-design-infrastructure"
 )
 
 $PluginDirs = @{
@@ -64,8 +64,9 @@ $PluginDirs = @{
     "chip-design-pd"           = "pd"
     "chip-design-soc"          = "soc"
     "chip-design-compiler"     = "compiler"
-    "chip-design-firmware"     = "firmware"
-    "chip-design-fpga"         = "fpga"
+    "chip-design-firmware"       = "firmware"
+    "chip-design-fpga"           = "fpga"
+    "chip-design-infrastructure" = "infrastructure"
 }
 
 # Helper: run a Python script stored in a temp file, then clean up
@@ -136,7 +137,7 @@ plugins = [
   "chip-design-formal",       "chip-design-synthesis", "chip-design-dft",
   "chip-design-sta",          "chip-design-hls",       "chip-design-pd",
   "chip-design-soc",          "chip-design-compiler",  "chip-design-firmware",
-  "chip-design-fpga",
+  "chip-design-fpga",         "chip-design-infrastructure",
 ]
 
 cfg = {}
@@ -162,7 +163,7 @@ print(f"  [OK] {len(plugins)} plugins enabled in settings.json")
     Invoke-PythonScript -ScriptContent $SettingsPy -Args @($Settings, $Marketplace, $RepoDir)
 
     Write-Host ""
-    Write-Host "Done! Restart Claude Code to activate all 13 plugins."
+    Write-Host "Done! Restart Claude Code to activate all 14 plugins."
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,7 @@ PLUGINS=(
   "chip-design-compiler"
   "chip-design-firmware"
   "chip-design-fpga"
+  "chip-design-infrastructure"
 )
 
 # ── Plugin → source directory mapping ────────────────────────────────────────
@@ -88,6 +89,7 @@ declare -A PLUGIN_DIRS=(
   ["chip-design-compiler"]="compiler"
   ["chip-design-firmware"]="firmware"
   ["chip-design-fpga"]="fpga"
+  ["chip-design-infrastructure"]="infrastructure"
 )
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -146,7 +148,7 @@ plugins = [
   "chip-design-formal",       "chip-design-synthesis", "chip-design-dft",
   "chip-design-sta",          "chip-design-hls",       "chip-design-pd",
   "chip-design-soc",          "chip-design-compiler",  "chip-design-firmware",
-  "chip-design-fpga",
+  "chip-design-fpga",         "chip-design-infrastructure",
 ]
 
 cfg = {}
@@ -171,7 +173,7 @@ print(f"  [OK] {len(plugins)} plugins enabled in settings.json")
 PYEOF
 
   echo ""
-  echo "Done! Restart Claude Code to activate all 13 plugins."
+  echo "Done! Restart Claude Code to activate all 14 plugins."
 
 fi  # end Claude Code block
 

--- a/plugins/infrastructure/.claude-plugin/plugin.json
+++ b/plugins/infrastructure/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "chip-design-infrastructure",
+  "version": "1.2.0",
+  "description": "EDA tool detection, output-filtering shell wrappers, and MCP server config templates for all chip-design domain agents",
+  "author": { "name": "chuanseng-ng", "url": "https://github.com/chuanseng-ng" },
+  "homepage": "https://github.com/chuanseng-ng/digital-chip-design-agents",
+  "repository": "https://github.com/chuanseng-ng/digital-chip-design-agents",
+  "license": "MIT",
+  "skills": ["./skills/infrastructure"],
+  "agents": ["./agents/infrastructure-orchestrator.md"]
+}

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -1,0 +1,89 @@
+---
+name: infrastructure-orchestrator
+description: >
+  Orchestrates EDA tool detection, output-filtering wrapper deployment, and MCP
+  server configuration. Invoke when setting up a chip-design environment, verifying
+  tool availability before running a domain orchestrator, or generating
+  install-missing-tools.sh for a new workstation.
+model: sonnet
+effort: high
+maxTurns: 40
+skills:
+  - digital-chip-design-agents:infrastructure
+---
+
+You are the Infrastructure Setup Orchestrator for chip design.
+
+You survey the host environment for open-source and proprietary EDA tools, generate
+an installation script for missing tools, deploy output-filtering shell wrappers, and
+configure MCP server templates — so every downstream domain orchestrator receives
+compact JSON instead of raw 10,000–50,000-line tool logs.
+
+## Stage Sequence
+tool_discovery → tool_installation → wrapper_deployment → mcp_configuration → environment_validation
+
+## Tool Options
+
+### Open-Source
+- Verilator (`verilator`), Slang (`slang`), Surelog (`surelog`), sv2v (`sv2v`), Icarus Verilog (`iverilog`)
+- Yosys (`yosys`), ABC (`abc`), OpenROAD (`openroad`), LibreLane/OpenLane2 (`openlane`)
+- KLayout (`klayout`), OpenSTA (`sta`), SymbiYosys (`sby`)
+- gem5 (`gem5`), Bambu HLS (`bambu-hls`), nextpnr (`nextpnr`), openFPGALoader (`openFPGALoader`)
+- cocotb (Python package), LLVM (`llvm-config`), GCC (`gcc`), OpenOCD (`openocd`)
+
+### Proprietary (detect only — never install)
+- Synopsys VCS, Cadence Xcelium, Synopsys Design Compiler
+- Cadence Innovus, Mentor QuestaSim, Synopsys PrimeTime, Synopsys Formality
+
+## Loop-Back Rules
+- tool_discovery FAIL (python3 missing)                         → escalate immediately (python3 required for all wrappers)
+- environment_validation FAIL (critical tool missing)           → tool_installation    (max 2×)
+- wrapper_deployment FAIL (permission denied)                   → escalate with `sudo chmod +x plugins/infrastructure/tools/*.sh`
+
+## State Object
+Initialise and maintain this JSON state across all stages:
+```json
+{
+  "run_id": "infra_001",
+  "host": "<from environment>",
+  "stages": {
+    "tool_discovery":        { "status": "pending", "output": {} },
+    "tool_installation":     { "status": "pending", "output": {} },
+    "wrapper_deployment":    { "status": "pending", "output": {} },
+    "mcp_configuration":     { "status": "pending", "output": {} },
+    "environment_validation":{ "status": "pending", "output": {} }
+  },
+  "tools_found": [],
+  "tools_missing": [],
+  "wrappers_deployed": 0,
+  "mcp_servers_configured": 0,
+  "loop_count": {},
+  "current_stage": null,
+  "flow_status": "not_started"
+}
+```
+
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "qor": {
+    "tools_detected": 0,
+    "tools_missing": 0,
+    "wrappers_deployed": 0,
+    "mcp_servers_configured": 0
+  },
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "recommendation": "proceed | loop_back_to:<stage> | escalate",
+  "output": {}
+}
+```
+
+## Behaviour Rules
+1. Read the infrastructure skill before executing each stage
+2. Enforce loop-back rules strictly — do not proceed past a FAIL
+3. If max iterations exceeded: stop, present full state and escalation report
+4. Never auto-run `install-missing-tools.sh` — present it to the user for review
+5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, and MCP snippets printed

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -36,7 +36,7 @@ tool_discovery → tool_installation → wrapper_deployment → mcp_configuratio
 - Cadence Innovus, Mentor QuestaSim, Synopsys PrimeTime, Synopsys Formality
 
 ## Loop-Back Rules
-- tool_discovery FAIL (python3 missing)                         → escalate immediately (python3 required for all wrappers)
+- tool_installation FAIL (python3 missing)                      → escalate immediately (python3 required for all wrappers)
 - environment_validation FAIL (critical tool missing)           → tool_installation    (max 2×)
 - wrapper_deployment FAIL (permission denied)                   → escalate with `sudo chmod +x plugins/infrastructure/tools/*.sh`
 

--- a/plugins/infrastructure/mcp/mcp-openroad.json
+++ b/plugins/infrastructure/mcp/mcp-openroad.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "OpenROAD MCP server — paste the mcpServers block into your .claude/settings.json",
+  "mcpServers": {
+    "openroad": {
+      "type": "stdio",
+      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-openroad.sh",
+      "args": []
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-opensta.json
+++ b/plugins/infrastructure/mcp/mcp-opensta.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "OpenSTA MCP server — paste the mcpServers block into your .claude/settings.json",
+  "mcpServers": {
+    "opensta": {
+      "type": "stdio",
+      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-opensta.sh",
+      "args": []
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-yosys.json
+++ b/plugins/infrastructure/mcp/mcp-yosys.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Yosys MCP server — paste the mcpServers block into your .claude/settings.json",
+  "mcpServers": {
+    "yosys": {
+      "type": "stdio",
+      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-yosys.sh",
+      "args": []
+    }
+  }
+}

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -57,13 +57,13 @@ complete environment before any domain orchestrator begins work.
 - **OpenOCD** (`openocd`) — on-chip debugger
 
 ### Proprietary (detect only — never install)
-- **Synopsys VCS** — industry-standard RTL simulator
-- **Cadence Xcelium** — next-generation simulation platform
-- **Synopsys Design Compiler** — logic synthesis
-- **Cadence Innovus** — physical implementation
-- **Mentor QuestaSim** — advanced simulation and verification
-- **Synopsys PrimeTime** — sign-off static timing analysis
-- **Synopsys Formality** — formal equivalence checking
+- **Synopsys VCS** (`vcs`) — industry-standard RTL simulator
+- **Cadence Xcelium** (`xrun`, alt: `xmsim`) — next-generation simulation platform
+- **Synopsys Design Compiler** (`dc_shell`, alt: `dc_shell-t`) — logic synthesis
+- **Cadence Innovus** (`innovus`) — physical implementation
+- **Mentor QuestaSim** (`vsim`, alt: `questa`, `questasim`) — advanced simulation and verification
+- **Synopsys PrimeTime** (`pt_shell`, alt: `pt_shell64`) — sign-off static timing analysis
+- **Synopsys Formality** (`formality`, alt: `fm_shell`) — formal equivalence checking
 
 ---
 
@@ -80,11 +80,12 @@ When running tools, prefer in this order:
 
 ### Domain Rules
 1. Run `which <command>` and `<command> --version` (or `-version`) for every open-source tool
-2. For proprietary tools: check PATH only (`which <command>`); never attempt install
-3. Record each tool as one of: `FOUND`, `MISSING`, or `PROPRIETARY_ONLY`
-4. Capture exact version string for each `FOUND` tool
-5. Never attempt installation in this stage
-6. Write results to `tool-status.json` before advancing
+2. **Exception — Python packages**: for `cocotb`, use `cocotb-config --version` (not `which cocotb`) to determine FOUND and capture the version string; report MISSING if `cocotb-config` is absent or returns non-zero
+3. For proprietary tools: check PATH using `which <primary-executable>` only (see executable names in the Proprietary section above); never attempt install; record as `PROPRIETARY_ONLY` if found, `MISSING` otherwise
+4. Record each tool as one of: `FOUND`, `MISSING`, or `PROPRIETARY_ONLY`
+5. Capture exact version string for each `FOUND` tool
+6. Never attempt installation in this stage
+7. Write results to `tool-status.json` before advancing
 
 ### QoR Metrics to Evaluate
 - `tools_detected`: count of FOUND tools (target ≥ 10 for a functional open-source flow)
@@ -109,6 +110,7 @@ When running tools, prefer in this order:
 6. Write `tool-manifest.json` reflecting confirmed tool state after user runs the script
 
 ### Common Issues & Fixes
+
 | Issue | Fix |
 |-------|-----|
 | `python3` not found | Escalate immediately — all wrapper scripts depend on it |

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: infrastructure
+description: >
+  EDA tool detection, wrapper deployment, and MCP configuration for digital chip
+  design environments. Use when setting up a new workstation, verifying tool
+  availability before a domain flow, or generating install-missing-tools.sh.
+version: 1.0.0
+author: chuanseng-ng
+license: MIT
+allowed-tools: Read, Write, Bash
+---
+
+# Skill: Infrastructure Setup
+
+## Invocation
+
+- **If invoked by a user** presenting a setup task: immediately spawn the
+  `digital-chip-design-agents:infrastructure-orchestrator` agent and pass the full
+  user request and any available context. Do not execute stages directly.
+- **If invoked by the `infrastructure-orchestrator` mid-flow**: do not spawn a new
+  agent. Treat this file as read-only — return the requested stage rules,
+  sign-off criteria, or loop-back guidance to the calling orchestrator.
+
+Spawning the orchestrator from within an active orchestrator run causes recursive
+delegation and must never happen.
+
+## Purpose
+Detect open-source and proprietary EDA tools, generate an installation script for
+missing tools, deploy output-filtering shell wrappers that emit compact JSON instead
+of raw 10,000–50,000-line logs, configure MCP server templates, and validate the
+complete environment before any domain orchestrator begins work.
+
+---
+
+## Supported EDA Tools
+
+### Open-Source
+- **Verilator** (`verilator`) — fast RTL simulator and linter
+- **Slang** (`slang`) — SystemVerilog compiler and language server
+- **Surelog** (`surelog`) — SystemVerilog pre-processor and parser
+- **sv2v** (`sv2v`) — SystemVerilog to Verilog converter
+- **Icarus Verilog** (`iverilog`) — Verilog simulator
+- **Yosys** (`yosys`) — open synthesis framework
+- **ABC** (`abc`) — logic synthesis and verification tool
+- **OpenROAD** (`openroad`) — RTL-to-GDS flow
+- **LibreLane / OpenLane2** (`openlane`) — open-source ASIC flow
+- **KLayout** (`klayout`) — GDS/OASIS viewer and DRC engine
+- **OpenSTA** (`sta`) — gate-level static timing analysis
+- **SymbiYosys** (`sby`) — formal hardware verification
+- **gem5** (`gem5`) — full-system micro-architectural simulator
+- **Bambu HLS** (`bambu-hls`) — high-level synthesis from C/C++
+- **nextpnr** (`nextpnr`) — FPGA place-and-route
+- **openFPGALoader** (`openFPGALoader`) — FPGA programming tool
+- **cocotb** (Python package `cocotb`) — Python-based RTL co-simulation
+- **LLVM** (`llvm-config`) — compiler infrastructure
+- **GCC** (`gcc`) — GNU compiler collection
+- **OpenOCD** (`openocd`) — on-chip debugger
+
+### Proprietary (detect only — never install)
+- **Synopsys VCS** — industry-standard RTL simulator
+- **Cadence Xcelium** — next-generation simulation platform
+- **Synopsys Design Compiler** — logic synthesis
+- **Cadence Innovus** — physical implementation
+- **Mentor QuestaSim** — advanced simulation and verification
+- **Synopsys PrimeTime** — sign-off static timing analysis
+- **Synopsys Formality** — formal equivalence checking
+
+---
+
+## Execution Hierarchy
+
+When running tools, prefer in this order:
+1. **MCP server** (lowest overhead, structured output directly in Claude context)
+2. **Wrapper script** (structured JSON output, tool not configured as MCP)
+3. **Direct execution** (last resort — raw log, no structured output)
+
+---
+
+## Stage: tool_discovery
+
+### Domain Rules
+1. Run `which <command>` and `<command> --version` (or `-version`) for every open-source tool
+2. For proprietary tools: check PATH only (`which <command>`); never attempt install
+3. Record each tool as one of: `FOUND`, `MISSING`, or `PROPRIETARY_ONLY`
+4. Capture exact version string for each `FOUND` tool
+5. Never attempt installation in this stage
+6. Write results to `tool-status.json` before advancing
+
+### QoR Metrics to Evaluate
+- `tools_detected`: count of FOUND tools (target ≥ 10 for a functional open-source flow)
+- `tools_missing`: count of MISSING open-source tools
+- `proprietary_found`: count of PROPRIETARY_ONLY tools detected in PATH
+
+### Output Required
+- `tool-status.json` — array of `{ "tool": "", "command": "", "status": "FOUND|MISSING|PROPRIETARY_ONLY", "version": "", "path": "" }`
+
+---
+
+## Stage: tool_installation
+
+### Domain Rules
+1. **Never auto-run installs** — only generate `install-missing-tools.sh`
+2. Script must include package-manager commands for each missing tool:
+   - apt-get (Ubuntu/Debian), brew (macOS), pacman (Arch) where available
+   - fall back to build-from-source instructions when no package exists
+3. Mark proprietary tools as "# manual install required — see vendor docs"
+4. If `python3` is missing: FAIL immediately and escalate — required for wrappers
+5. Include `chmod +x` calls for all wrapper scripts at the end of the install script
+6. Write `tool-manifest.json` reflecting confirmed tool state after user runs the script
+
+### Common Issues & Fixes
+| Issue | Fix |
+|-------|-----|
+| `python3` not found | Escalate immediately — all wrapper scripts depend on it |
+| OpenROAD build required | Refer to https://github.com/The-OpenROAD-Project/OpenROAD |
+| Bambu HLS Linux only | Wrap with `status: WARN` on macOS/Windows |
+
+### Output Required
+- `install-missing-tools.sh` — executable install script for all MISSING tools
+- `tool-manifest.json` — final confirmed tool list after installation
+
+---
+
+## Stage: wrapper_deployment
+
+### Domain Rules
+1. Deploy all 8 wrapper scripts to `plugins/infrastructure/tools/`
+2. Run `chmod +x` on every wrapper; if permission denied: FAIL and escalate with
+   `sudo chmod +x` instructions
+3. Every wrapper must emit JSON conforming to the schema below regardless of exit code
+4. Test each wrapper with `--version` or `--help` after deploy; tolerate MISSING tools
+   (wrappers must handle tool-not-found gracefully with `status: "FAIL"`)
+5. Never suppress the tool's original exit code
+
+### Wrapper JSON Output Schema
+Every wrapper script must print exactly this JSON structure to stdout:
+```json
+{
+  "tool": "<tool-name>",
+  "exit_code": 0,
+  "status": "PASS|FAIL|WARN",
+  "summary": {},
+  "errors": [],
+  "warnings": [],
+  "raw_log": "/tmp/<tool>-XXXXXX.log"
+}
+```
+
+Fields:
+- `status`: `PASS` if exit_code == 0 and no errors; `FAIL` if exit_code != 0 or tool not found; `WARN` if exit_code == 0 with warnings
+- `summary`: tool-specific metrics (cells, timing, coverage, etc.)
+- `raw_log`: absolute path to temp file containing full unfiltered output
+
+### QoR Metrics to Evaluate
+- `wrappers_deployed`: count of wrapper scripts with executable bit set (target: 8)
+
+### Output Required
+- 8 executable wrapper scripts in `plugins/infrastructure/tools/`
+
+---
+
+## Stage: mcp_configuration
+
+### Domain Rules
+1. Emit MCP config snippets for OpenROAD, Yosys, and OpenSTA pointing to their wrappers
+2. Config must use `"type": "stdio"` and an absolute path to the wrapper as `command`
+3. Print each snippet with explicit instruction:
+   "Paste the `mcpServers` block into your `.claude/settings.json`"
+4. Write the snippet files to `plugins/infrastructure/mcp/`
+5. Do not modify `.claude/settings.json` automatically — user must do this manually
+
+### MCP Config Template
+```json
+{
+  "mcpServers": {
+    "<tool>": {
+      "type": "stdio",
+      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-<tool>.sh",
+      "args": []
+    }
+  }
+}
+```
+
+### QoR Metrics to Evaluate
+- `mcp_servers_configured`: count of MCP snippet files written (target: 3)
+
+### Output Required
+- `plugins/infrastructure/mcp/mcp-yosys.json`
+- `plugins/infrastructure/mcp/mcp-openroad.json`
+- `plugins/infrastructure/mcp/mcp-opensta.json`
+- Printed MCP config snippets for each tool
+
+---
+
+## Stage: environment_validation
+
+### Domain Rules
+1. Re-run tool presence checks against `tool-manifest.json`
+2. Verify all 8 wrapper scripts exist and have executable bit set
+3. Verify MCP snippet files are present in `plugins/infrastructure/mcp/`
+4. FAIL if any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) is still missing
+5. Print final sign-off summary: tools detected, wrappers deployed, MCP servers configured
+
+### Sign-off Checklist
+- [ ] `tool-status.json` written with all tools surveyed
+- [ ] `install-missing-tools.sh` generated (auto-run is user's choice)
+- [ ] `tool-manifest.json` written
+- [ ] All 8 wrappers deployed and executable
+- [ ] MCP config snippets written and printed
+- [ ] No critical-path tools missing
+
+### Output Required
+- Printed environment validation report
+- Updated `tool-manifest.json` with final confirmed state

--- a/plugins/infrastructure/tools/wrap-bambu.sh
+++ b/plugins/infrastructure/tools/wrap-bambu.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# wrap-bambu.sh — run Bambu HLS and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="bambu-hls"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"bambu","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: bambu-hls"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/bambu-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys, os
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+# Bambu may write an XML report; try to parse it
+latency_m = re.search(r'Total latency[^\d]*([\d.]+)\s*cycles?', text, re.I)
+dsp_m     = re.search(r'DSP\s+(\d+)', text, re.I)
+bram_m    = re.search(r'BRAM\s+(\d+)', text, re.I)
+
+# Also try parsing HLS report XML if present
+xml_candidates = [f for f in os.listdir('.') if f.endswith('_results.xml') or 'hls_report' in f]
+for xf in xml_candidates:
+    try:
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(xf)
+        root = tree.getroot()
+        for tag, key in [('Latency', 'latency_cycles'), ('DSPs', 'dsp_count'), ('BRAMs', 'bram_count')]:
+            el = root.find('.//' + tag)
+            if el is not None and el.text:
+                try:
+                    summary_from_xml[key] = int(el.text)
+                except ValueError:
+                    pass
+    except Exception:
+        pass
+
+summary = {}
+if latency_m: summary["latency_cycles"] = float(latency_m.group(1))
+if dsp_m:     summary["dsp_count"]      = int(dsp_m.group(1))
+if bram_m:    summary["bram_count"]     = int(bram_m.group(1))
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+
+print(json.dumps({
+    "tool":      "bambu",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-bambu.sh
+++ b/plugins/infrastructure/tools/wrap-bambu.sh
@@ -16,22 +16,24 @@ PYEOF
 fi
 
 LOG=$(mktemp /tmp/bambu-XXXXXX.log)
+START_TS=$(date +%s)
 set +e
 "$TOOL" "$@" >"$LOG" 2>&1
 EXIT_CODE=$?
 set -e
 
-python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+python3 - "$LOG" "$EXIT_CODE" "$START_TS" <<'PYEOF'
 import json, re, sys, os
 
-log_path = sys.argv[1]
-exit_code = int(sys.argv[2])
+log_path        = sys.argv[1]
+exit_code       = int(sys.argv[2])
+invocation_start = float(sys.argv[3]) if len(sys.argv) > 3 else 0.0
 
 with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
-warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN(?:ING)?\b', l, re.I)]
 
 # Bambu may write an XML report; try to parse it
 latency_m = re.search(r'Total latency[^\d]*([\d.]+)\s*cycles?', text, re.I)
@@ -42,7 +44,8 @@ bram_m    = re.search(r'BRAM\s+(\d+)', text, re.I)
 import xml.etree.ElementTree as ET
 import sys as _sys
 summary_from_xml = {}
-xml_candidates = [f for f in os.listdir('.') if f.endswith('_results.xml') or 'hls_report' in f]
+xml_candidates = [f for f in os.listdir('.') if (f.endswith('_results.xml') or 'hls_report' in f)
+                  and os.path.getmtime(f) >= invocation_start]
 for xf in xml_candidates:
     try:
         tree = ET.parse(xf)

--- a/plugins/infrastructure/tools/wrap-bambu.sh
+++ b/plugins/infrastructure/tools/wrap-bambu.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 TOOL="bambu-hls"
 
 if ! command -v "$TOOL" &>/dev/null; then
-  python3 - <<'PYEOF'
-import json
-print(json.dumps({"tool":"bambu","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: bambu-hls"],"warnings":[],"raw_log":""}))
+  _LOG=$(mktemp /tmp/bambu-notfound-XXXXXX.log)
+  echo "tool not found: bambu-hls" > "$_LOG"
+  python3 - "$_LOG" <<'PYEOF'
+import json, sys
+log_path = sys.argv[1]
+print(json.dumps({"tool":"bambu","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: bambu-hls"],"warnings":[],"raw_log":log_path}))
 PYEOF
   exit 1
 fi
@@ -24,7 +27,7 @@ import json, re, sys, os
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
@@ -36,10 +39,12 @@ dsp_m     = re.search(r'DSP\s+(\d+)', text, re.I)
 bram_m    = re.search(r'BRAM\s+(\d+)', text, re.I)
 
 # Also try parsing HLS report XML if present
+import xml.etree.ElementTree as ET
+import sys as _sys
+summary_from_xml = {}
 xml_candidates = [f for f in os.listdir('.') if f.endswith('_results.xml') or 'hls_report' in f]
 for xf in xml_candidates:
     try:
-        import xml.etree.ElementTree as ET
         tree = ET.parse(xf)
         root = tree.getroot()
         for tag, key in [('Latency', 'latency_cycles'), ('DSPs', 'dsp_count'), ('BRAMs', 'bram_count')]:
@@ -49,17 +54,24 @@ for xf in xml_candidates:
                     summary_from_xml[key] = int(el.text)
                 except ValueError:
                     pass
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"[wrap-bambu] warning: could not parse {xf}: {e}", file=_sys.stderr)
 
 summary = {}
 if latency_m: summary["latency_cycles"] = float(latency_m.group(1))
 if dsp_m:     summary["dsp_count"]      = int(dsp_m.group(1))
 if bram_m:    summary["bram_count"]     = int(bram_m.group(1))
+# Merge XML-derived values for any metrics not already captured by regex
+if "latency_cycles" not in summary and "latency_cycles" in summary_from_xml:
+    summary["latency_cycles"] = float(summary_from_xml["latency_cycles"])
+if "dsp_count" not in summary and "dsp_count" in summary_from_xml:
+    summary["dsp_count"] = int(summary_from_xml["dsp_count"])
+if "bram_count" not in summary and "bram_count" in summary_from_xml:
+    summary["bram_count"] = int(summary_from_xml["bram_count"])
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+status = "FAIL" if exit_code != 0 or errors else ("WARN" if warnings else "PASS")
 
 print(json.dumps({
     "tool":      "bambu",

--- a/plugins/infrastructure/tools/wrap-gem5.sh
+++ b/plugins/infrastructure/tools/wrap-gem5.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 TOOL="gem5"
 
 if ! command -v "$TOOL" &>/dev/null; then
-  python3 - <<'PYEOF'
-import json
-print(json.dumps({"tool":"gem5","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: gem5"],"warnings":[],"raw_log":""}))
+  _LOG=$(mktemp /tmp/gem5-notfound-XXXXXX.log)
+  echo "tool not found: gem5" > "$_LOG"
+  python3 - "$_LOG" <<'PYEOF'
+import json, sys
+log_path = sys.argv[1]
+print(json.dumps({"tool":"gem5","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: gem5"],"warnings":[],"raw_log":log_path}))
 PYEOF
   exit 1
 fi
@@ -24,7 +27,7 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b|panic|fatal', l, re.I)]
@@ -41,7 +44,7 @@ if ipc_m:       summary["ipc"]          = float(ipc_m.group(1))
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+status = "FAIL" if exit_code != 0 or errors else ("WARN" if warnings else "PASS")
 
 print(json.dumps({
     "tool":      "gem5",

--- a/plugins/infrastructure/tools/wrap-gem5.sh
+++ b/plugins/infrastructure/tools/wrap-gem5.sh
@@ -31,7 +31,7 @@ with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b|panic|fatal', l, re.I)]
-warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN(?:ING)?\b', l, re.I)]
 
 sim_insts_m   = re.search(r'simInsts\s+(\d+)', text)
 host_secs_m   = re.search(r'hostSeconds\s+([\d.]+)', text)

--- a/plugins/infrastructure/tools/wrap-gem5.sh
+++ b/plugins/infrastructure/tools/wrap-gem5.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# wrap-gem5.sh — run gem5 and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="gem5"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"gem5","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: gem5"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/gem5-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b|panic|fatal', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b', l, re.I)]
+
+sim_insts_m   = re.search(r'simInsts\s+(\d+)', text)
+host_secs_m   = re.search(r'hostSeconds\s+([\d.]+)', text)
+ipc_m         = re.search(r'\bipc\b\s+([\d.]+)', text, re.I)
+
+summary = {}
+if sim_insts_m: summary["sim_insts"]    = int(sim_insts_m.group(1))
+if host_secs_m: summary["host_seconds"] = float(host_secs_m.group(1))
+if ipc_m:       summary["ipc"]          = float(ipc_m.group(1))
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+
+print(json.dumps({
+    "tool":      "gem5",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-klayout.sh
+++ b/plugins/infrastructure/tools/wrap-klayout.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# wrap-klayout.sh — run KLayout DRC and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="klayout"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"klayout","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: klayout"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/klayout-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys, os, glob
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+# Parse KLayout DRC report XML (*.lyrdb or *.xml) if present
+drc_categories = {}
+total_drc = 0
+
+for report_file in glob.glob('*.lyrdb') + glob.glob('*drc*.xml'):
+    try:
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(report_file)
+        root = tree.getroot()
+        for cat in root.findall('.//category'):
+            name_el = cat.find('name')
+            items   = cat.findall('.//item')
+            if name_el is not None:
+                cat_name  = name_el.text or "unknown"
+                cat_count = len(items)
+                drc_categories[cat_name] = cat_count
+                total_drc += cat_count
+    except Exception:
+        pass
+
+# Fallback: parse text log for DRC count
+if not drc_categories:
+    drc_m = re.search(r'(\d+)\s+(?:DRC\s+)?(?:error|violation)', text, re.I)
+    if drc_m:
+        total_drc = int(drc_m.group(1))
+
+summary = {
+    "drc_total":      total_drc,
+    "drc_categories": drc_categories,
+    "error_count":    len(errors),
+    "warning_count":  len(warnings),
+}
+
+if exit_code != 0 or errors:
+    status = "FAIL"
+elif total_drc > 0:
+    status = "WARN"
+else:
+    status = "PASS"
+
+print(json.dumps({
+    "tool":      "klayout",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-klayout.sh
+++ b/plugins/infrastructure/tools/wrap-klayout.sh
@@ -13,28 +13,31 @@ PYEOF
 fi
 
 LOG=$(mktemp /tmp/klayout-XXXXXX.log)
+START_EPOCH=$(python3 -c "import time; print(time.time())")
 set +e
 "$TOOL" "$@" >"$LOG" 2>&1
 EXIT_CODE=$?
 set -e
 
-python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+python3 - "$LOG" "$EXIT_CODE" "$START_EPOCH" <<'PYEOF'
 import json, re, sys, os, glob
 
-log_path = sys.argv[1]
-exit_code = int(sys.argv[2])
+log_path        = sys.argv[1]
+exit_code       = int(sys.argv[2])
+invocation_start = float(sys.argv[3]) if len(sys.argv) > 3 else 0.0
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
-warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN(?:ING)?\b', l, re.I)]
 
 # Parse KLayout DRC report XML (*.lyrdb or *.xml) if present
 drc_categories = {}
 total_drc = 0
 
-for report_file in glob.glob('*.lyrdb') + glob.glob('*drc*.xml'):
+for report_file in [f for f in glob.glob('*.lyrdb') + glob.glob('*drc*.xml')
+                    if os.path.getmtime(f) >= invocation_start]:
     try:
         import xml.etree.ElementTree as ET
         tree = ET.parse(report_file)
@@ -65,7 +68,7 @@ summary = {
 
 if exit_code != 0 or errors:
     status = "FAIL"
-elif total_drc > 0:
+elif total_drc > 0 or warnings:
     status = "WARN"
 else:
     status = "PASS"

--- a/plugins/infrastructure/tools/wrap-openroad.sh
+++ b/plugins/infrastructure/tools/wrap-openroad.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# wrap-openroad.sh — run OpenROAD and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="openroad"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"openroad","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: openroad"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/openroad-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+wns_m  = re.search(r'wns\s+([-\d.]+)', text)
+tns_m  = re.search(r'tns\s+([-\d.]+)', text)
+drc_m  = re.search(r'(\d+)\s+(?:DRC\s+)?violations?', text, re.I)
+
+summary = {}
+if wns_m:  summary["wns_ns"]       = float(wns_m.group(1))
+if tns_m:  summary["tns_ns"]       = float(tns_m.group(1))
+if drc_m:  summary["drc_violations"] = int(drc_m.group(1))
+
+progress = re.findall(r'\[INFO\][^\n]+', text)
+summary["progress_messages"] = progress[-5:] if progress else []
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+
+print(json.dumps({
+    "tool":      "openroad",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-openroad.sh
+++ b/plugins/infrastructure/tools/wrap-openroad.sh
@@ -24,7 +24,7 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
@@ -44,7 +44,7 @@ summary["progress_messages"] = progress[-5:] if progress else []
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+status = "FAIL" if exit_code != 0 or errors else ("WARN" if warnings else "PASS")
 
 print(json.dumps({
     "tool":      "openroad",

--- a/plugins/infrastructure/tools/wrap-opensta.sh
+++ b/plugins/infrastructure/tools/wrap-opensta.sh
@@ -13,10 +13,15 @@ PYEOF
 fi
 
 LOG=$(mktemp /tmp/opensta-XXXXXX.log)
-set +e
-"$TOOL" "$@" >"$LOG" 2>&1
-EXIT_CODE=$?
-set -e
+if [[ $# -eq 0 ]]; then
+  echo "error: no arguments provided; sta requires a script file (interactive mode not supported)" >"$LOG"
+  EXIT_CODE=1
+else
+  set +e
+  "$TOOL" "$@" >"$LOG" 2>&1
+  EXIT_CODE=$?
+  set -e
+fi
 
 python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
 import json, re, sys

--- a/plugins/infrastructure/tools/wrap-opensta.sh
+++ b/plugins/infrastructure/tools/wrap-opensta.sh
@@ -24,11 +24,11 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
-warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN(?:ING)?\b', l, re.I)]
 
 wns_m     = re.search(r'wns\s+([-\d.]+)', text)
 tns_m     = re.search(r'tns\s+([-\d.]+)', text)
@@ -41,7 +41,7 @@ if endpoint_m: summary["worst_endpoint"]    = endpoint_m.group(1)
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+status = "FAIL" if exit_code != 0 or errors else ("WARN" if warnings else "PASS")
 
 print(json.dumps({
     "tool":      "opensta",

--- a/plugins/infrastructure/tools/wrap-opensta.sh
+++ b/plugins/infrastructure/tools/wrap-opensta.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# wrap-opensta.sh — run OpenSTA and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="sta"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"opensta","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: sta (OpenSTA)"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/opensta-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+wns_m     = re.search(r'wns\s+([-\d.]+)', text)
+tns_m     = re.search(r'tns\s+([-\d.]+)', text)
+endpoint_m = re.search(r'Worst slack.*?endpoint\s+(\S+)', text, re.I | re.S)
+
+summary = {}
+if wns_m:      summary["wns_ns"]            = float(wns_m.group(1))
+if tns_m:      summary["tns_ns"]            = float(tns_m.group(1))
+if endpoint_m: summary["worst_endpoint"]    = endpoint_m.group(1)
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+
+print(json.dumps({
+    "tool":      "opensta",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-symbiflow.sh
+++ b/plugins/infrastructure/tools/wrap-symbiflow.sh
@@ -24,7 +24,7 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
@@ -50,9 +50,9 @@ if counterexample_m:
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-if failed_props or exit_code != 0:
+if errors or failed_props or exit_code != 0:
     status = "FAIL"
-elif unknown_props:
+elif warnings or unknown_props:
     status = "WARN"
 else:
     status = "PASS"

--- a/plugins/infrastructure/tools/wrap-symbiflow.sh
+++ b/plugins/infrastructure/tools/wrap-symbiflow.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# wrap-symbiflow.sh — run SymbiYosys (sby) and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="sby"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"symbiyosys","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: sby (SymbiYosys)"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/symbiflow-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+proved_props  = re.findall(r'PROVED\s+(\S+)', text, re.I)
+failed_props  = re.findall(r'FAILED\s+(\S+)', text, re.I)
+unknown_props = re.findall(r'UNKNOWN\s+(\S+)', text, re.I)
+
+# Counterexample info: look for trace file references
+counterexample_m = re.search(r'Counterexample\s+written\s+to\s+(\S+)', text, re.I)
+
+summary = {
+    "proved":  proved_props,
+    "failed":  failed_props,
+    "unknown": unknown_props,
+    "proved_count":  len(proved_props),
+    "failed_count":  len(failed_props),
+    "unknown_count": len(unknown_props),
+}
+if counterexample_m:
+    summary["counterexample_trace"] = counterexample_m.group(1)
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+if failed_props or exit_code != 0:
+    status = "FAIL"
+elif unknown_props:
+    status = "WARN"
+else:
+    status = "PASS"
+
+print(json.dumps({
+    "tool":      "symbiyosys",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-verilator-sim.sh
+++ b/plugins/infrastructure/tools/wrap-verilator-sim.sh
@@ -3,12 +3,21 @@
 # Usage: wrap-verilator-sim.sh <sim_binary> [args...]
 set -euo pipefail
 
-TOOL="verilator"
-
-if ! command -v "$TOOL" &>/dev/null; then
+if [[ $# -lt 1 ]]; then
   python3 - <<'PYEOF'
 import json
-print(json.dumps({"tool":"verilator-sim","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: verilator"],"warnings":[],"raw_log":""}))
+print(json.dumps({"tool":"verilator-sim","exit_code":1,"status":"FAIL","summary":{},"errors":["no sim binary provided: usage: wrap-verilator-sim.sh <sim_binary> [args...]"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+SIM_BIN="$1"
+
+if [[ ! -x "$SIM_BIN" ]]; then
+  python3 - "$SIM_BIN" <<'PYEOF'
+import json, sys
+sim_bin = sys.argv[1]
+print(json.dumps({"tool":"verilator-sim","exit_code":1,"status":"FAIL","summary":{},"errors":[f"sim binary not found or not executable: {sim_bin}"],"warnings":[],"raw_log":""}))
 PYEOF
   exit 1
 fi
@@ -25,7 +34,7 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]

--- a/plugins/infrastructure/tools/wrap-verilator-sim.sh
+++ b/plugins/infrastructure/tools/wrap-verilator-sim.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# wrap-verilator-sim.sh — run Verilator simulation binary and emit a compact JSON summary
+# Usage: wrap-verilator-sim.sh <sim_binary> [args...]
+set -euo pipefail
+
+TOOL="verilator"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json
+print(json.dumps({"tool":"verilator-sim","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: verilator"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/verilator-sim-XXXXXX.log)
+set +e
+"$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+
+passed_m   = re.search(r'TEST PASSED', text, re.I)
+failed_m   = re.search(r'TEST FAILED', text, re.I)
+coverage_m = re.search(r'coverage[^\d]*([\d.]+)\s*%', text, re.I)
+
+summary = {}
+summary["test_passed"] = bool(passed_m)
+summary["test_failed"] = bool(failed_m)
+if coverage_m:
+    summary["coverage_pct"] = float(coverage_m.group(1))
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+if failed_m or exit_code != 0:
+    status = "FAIL"
+elif warnings:
+    status = "WARN"
+else:
+    status = "PASS"
+
+print(json.dumps({
+    "tool":      "verilator-sim",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-verilator-sim.sh
+++ b/plugins/infrastructure/tools/wrap-verilator-sim.sh
@@ -38,7 +38,7 @@ with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
-warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN\b',  l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARN(?:ING)?\b', l, re.I)]
 
 passed_m   = re.search(r'TEST PASSED', text, re.I)
 failed_m   = re.search(r'TEST FAILED', text, re.I)

--- a/plugins/infrastructure/tools/wrap-yosys.sh
+++ b/plugins/infrastructure/tools/wrap-yosys.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# wrap-yosys.sh — run Yosys and emit a compact JSON summary
+set -euo pipefail
+
+TOOL="yosys"
+
+if ! command -v "$TOOL" &>/dev/null; then
+  python3 - <<'PYEOF'
+import json, sys
+print(json.dumps({"tool":"yosys","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: yosys"],"warnings":[],"raw_log":""}))
+PYEOF
+  exit 1
+fi
+
+LOG=$(mktemp /tmp/yosys-XXXXXX.log)
+set +e
+"$TOOL" "$@" >"$LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+python3 - "$LOG" "$EXIT_CODE" <<'PYEOF'
+import json, re, sys
+
+log_path = sys.argv[1]
+exit_code = int(sys.argv[2])
+
+with open(log_path) as f:
+    text = f.read()
+
+errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
+warnings = [l.strip() for l in text.splitlines() if re.search(r'\bWARNING\b', l, re.I)]
+
+cells_m  = re.search(r'Number of cells:\s+(\d+)', text)
+area_m   = re.search(r'Chip area for (?:top )?module[^:]*:\s+([\d.]+)', text)
+
+summary = {}
+if cells_m:
+    summary["cells"] = int(cells_m.group(1))
+if area_m:
+    summary["chip_area_um2"] = float(area_m.group(1))
+summary["error_count"]   = len(errors)
+summary["warning_count"] = len(warnings)
+
+status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+
+print(json.dumps({
+    "tool":      "yosys",
+    "exit_code": exit_code,
+    "status":    status,
+    "summary":   summary,
+    "errors":    errors[:10],
+    "warnings":  warnings[:10],
+    "raw_log":   log_path
+}, indent=2))
+PYEOF
+
+exit $EXIT_CODE

--- a/plugins/infrastructure/tools/wrap-yosys.sh
+++ b/plugins/infrastructure/tools/wrap-yosys.sh
@@ -24,7 +24,7 @@ import json, re, sys
 log_path = sys.argv[1]
 exit_code = int(sys.argv[2])
 
-with open(log_path) as f:
+with open(log_path, encoding='utf-8', errors='replace') as f:
     text = f.read()
 
 errors   = [l.strip() for l in text.splitlines() if re.search(r'\bERROR\b', l, re.I)]
@@ -41,7 +41,7 @@ if area_m:
 summary["error_count"]   = len(errors)
 summary["warning_count"] = len(warnings)
 
-status = "PASS" if exit_code == 0 and not errors else ("WARN" if exit_code == 0 else "FAIL")
+status = "FAIL" if exit_code != 0 or errors else ("WARN" if warnings else "PASS")
 
 print(json.dumps({
     "tool":      "yosys",


### PR DESCRIPTION
# Scope
- Adds a new infrastructure plugin
  - Detects/installs open-source EDA tools
  - Deploys output-filtering shell wrappers (compact JSON output)
  - Provides MCP server config templates 
    - Downstream domain orchestrators receive structured data instead of raw 10k-50k-line tool logs.

# New files:
- plugins/infrastructure/.claude-plugin/plugin.json
- plugins/infrastructure/skills/infrastructure/SKILL.md (5 stages)
- plugins/infrastructure/agents/infrastructure-orchestrator.md
- plugins/infrastructure/tools/wrap-{yosys,openroad,opensta,gem5,bambu,verilator-sim,symbiflow,klayout}.sh
- plugins/infrastructure/mcp/mcp-{yosys,openroad,opensta}.json

# Modified files:
- .claude-plugin/marketplace.json (14th entry)
- install.sh / install.ps1 (arrays + count 13→14)
- .github/workflows/validate.yml (assertions 13→14)
- ides/copilot/applyto-map.json (infrastructure domain)
- docs/MASTER_INDEX.md (Step 0 diagram, table row, counts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Infrastructure Setup stage with an orchestrator agent and a new Infrastructure Setup skill
  * Introduced infrastructure plugin with wrapper-based support for multiple EDA tools and MCP server entries

* **Documentation**
  * Updated pipeline docs and index with the new Infrastructure Setup flow and artifact definitions

* **Chores**
  * Incremented domain/plugin counts and installer messages to reflect the added infrastructure domain
<!-- end of auto-generated comment: release notes by coderabbit.ai -->