### PR TITLE
[Feature] Add tool-based MCP for agents

### DIFF
--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -33,6 +33,12 @@ spec_analysis → arch_exploration → perf_modelling → power_area_estimation 
 - ARM Performance Models
 - Cadence Virtual System Platform (VSP)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `gem5` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-gem5.sh` (structured JSON with IPC/throughput summary)
+3. **Direct execution** — last resort; gem5 stats files are extremely large
+
 ## Loop-Back Rules
 - perf_modelling FAIL (throughput misses target)         → arch_exploration   (max 3×)
 - power_area_estimation FAIL (area or power > 80% budget) → arch_exploration   (max 2×)

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -27,6 +27,12 @@ dft_architecture → scan_insertion → atpg → bist_insertion → jtag_setup �
 - Cadence Modus Test (`modus`)
 - Siemens Tessent (`tessent`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `yosys` or `openroad` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-yosys.sh` / `wrap-openroad.sh` (structured JSON output)
+3. **Direct execution** — last resort; scan insertion and DRC logs can be very large
+
 ## Loop-Back Rules
 - scan_insertion FAIL (DRC errors > 0)            → scan_insertion  (max 3×)
 - atpg FAIL (SAF coverage < target)               → scan_insertion  (max 2×)

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -31,6 +31,12 @@ property_planning → environment_setup → fpv_run → cex_analysis → lec_run
 - Synopsys VC Formal (`vcf`)
 - Siemens Questa Formal (`qformal`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `yosys` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-yosys.sh` (structured JSON output)
+3. **Direct execution** — last resort; SymbiYosys/Yosys proof logs can be very large
+
 ## Loop-Back Rules
 - fpv_run: CEX found (RTL bug)           → (RTL fix required) → fpv_run    (unlimited, RTL-gated)
 - fpv_run: vacuous proof                 → environment_setup                (max 3×)

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -31,6 +31,12 @@ rtl_adaptation → partitioning → fpga_synthesis → bring_up → sw_validatio
 - Microchip Libero (`libero`)
 - Synopsys Synplify
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `yosys` or `symbiflow` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-yosys.sh` / `wrap-symbiflow.sh` (structured JSON output)
+3. **Direct execution** — last resort; FPGA synthesis and P&R logs are large
+
 ## Loop-Back Rules
 - fpga_synthesis FAIL (WNS < −0.5 ns)      → rtl_adaptation    (add pipeline regs) (max 3×)
 - fpga_synthesis FAIL (utilisation > 70%)  → partitioning                          (max 2×)

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -33,8 +33,10 @@ rtl_adaptation → partitioning → fpga_synthesis → bring_up → sw_validatio
 
 ### MCP Preference
 When invoking open-source tools, follow the execution hierarchy:
-1. **MCP server** — use `yosys` or `symbiflow` MCP if active in `.claude/settings.json` (lowest context overhead)
-2. **Wrapper script** — `wrap-yosys.sh` / `wrap-symbiflow.sh` (structured JSON output)
+1. **MCP server** — use `yosys` MCP for synthesis/P&R if active in `.claude/settings.json` (lowest context overhead);
+   use `symbiflow` MCP for bounded formal property checks only (`symbiflow` wraps SymbiYosys/`sby`,
+   not an FPGA synthesis tool — do not use it for `fpga_synthesis` or `partitioning` stages)
+2. **Wrapper script** — `wrap-yosys.sh` for synthesis; `wrap-symbiflow.sh` for formal checks (structured JSON output)
 3. **Direct execution** — last resort; FPGA synthesis and P&R logs are large
 
 ## Loop-Back Rules

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -30,6 +30,12 @@ algorithm_analysis → directive_planning → hls_synthesis → rtl_qc → cosim
 - Cadence Stratus (`stratus`)
 - Siemens Catapult (`catapult`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `bambu` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-bambu.sh` (structured JSON with latency/II/area metrics)
+3. **Direct execution** — last resort; Bambu HLS synthesis logs are large across directive iterations
+
 ## Loop-Back Rules
 - hls_synthesis FAIL (latency > target)   → directive_planning    (max 4×)
 - hls_synthesis FAIL (area > budget)      → directive_planning    (max 3×)

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -57,6 +57,7 @@ Initialise and maintain this JSON state across all stages:
   "tools_missing": [],
   "wrappers_deployed": 0,
   "mcp_servers_configured": 0,
+  "mcp_target": 10,
   "loop_count": {},
   "current_stage": null,
   "flow_status": "not_started"
@@ -86,4 +87,4 @@ Each stage must return:
 2. Enforce loop-back rules strictly — do not proceed past a FAIL
 3. If max iterations exceeded: stop, present full state and escalation report
 4. Never auto-run `install-missing-tools.sh` — present it to the user for review
-5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, and MCP snippets printed
+5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, `mcp-adapter.py` and `mcp-session-adapter.py` present, and all 10 MCP config snippets written with resolved absolute paths and printed

--- a/plugins/infrastructure/mcp/mcp-bambu.json
+++ b/plugins/infrastructure/mcp/mcp-bambu.json
@@ -12,7 +12,7 @@
       ],
       "env": {
         "BAMBU_HOME": "/path/to/bambu",
-        "HLS_TARGET_DEVICE": "xc7a200t-1fbg676",
+        "HLS_TARGET_DEVICE": "<set_to_target_device_part_number>",
         "TOOL_TIMEOUT_S": "600"
       }
     }

--- a/plugins/infrastructure/mcp/mcp-bambu.json
+++ b/plugins/infrastructure/mcp/mcp-bambu.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Bambu HLS batch MCP server — paste the mcpServers block into your .claude/settings.json. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "bambu": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-bambu.sh",
+        "--tool", "bambu",
+        "--description", "Run Bambu HLS synthesis and return compact JSON: latency_cycles, dsp_count, bram_count, error/warning counts"
+      ],
+      "env": {
+        "BAMBU_HOME": "/path/to/bambu",
+        "HLS_TARGET_DEVICE": "xc7a200t-1fbg676",
+        "TOOL_TIMEOUT_S": "600"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-gem5.json
+++ b/plugins/infrastructure/mcp/mcp-gem5.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "gem5 batch MCP server — suitable only for short targeted benchmark runs (minutes). Full-system simulations that take >10 min should be launched via Bash and results read from stats.txt directly. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "gem5": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-gem5.sh",
+        "--tool", "gem5",
+        "--description", "Run gem5 simulation and return compact JSON: sim_insts, ipc, host_seconds. Use only for short targeted runs; full-system runs should use Bash + read stats.txt."
+      ],
+      "env": {
+        "GEM5_HOME": "/path/to/gem5",
+        "M5_PATH": "/path/to/gem5/disk-images",
+        "GEM5_DEFAULT_ISA": "RISCV",
+        "TOOL_TIMEOUT_S": "600"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-klayout.json
+++ b/plugins/infrastructure/mcp/mcp-klayout.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "KLayout batch MCP server — paste the mcpServers block into your .claude/settings.json. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "klayout": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-klayout.sh",
+        "--tool", "klayout",
+        "--description", "Run KLayout DRC/LVS and return compact JSON: drc_total, per-category violation counts"
+      ],
+      "env": {
+        "KLAYOUT_HOME": "/path/to/klayout",
+        "DRC_RULE_DECK": "/path/to/pdk/klayout/sky130A.drc",
+        "TECH_FILE": "/path/to/pdk/klayout/sky130A.lyt",
+        "TOOL_TIMEOUT_S": "600"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-openroad-session.json
+++ b/plugins/infrastructure/mcp/mcp-openroad-session.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "OpenROAD interactive session MCP server — keeps a persistent openroad process alive between calls. Exposes load_design, query_timing, query_drc, get_design_area, get_power, run_tcl, close_design. Preferred over mcp-openroad.json for ECO iteration loops where the design is queried repeatedly. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "openroad-session": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-session-adapter.py",
+        "--tool", "openroad"
+      ],
+      "env": {
+        "OPENROAD_EXE": "openroad",
+        "PDK_ROOT": "/path/to/pdks",
+        "PLATFORM": "sky130hd",
+        "SESSION_TIMEOUT_S": "120",
+        "SESSION_STARTUP_S": "10"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-openroad.json
+++ b/plugins/infrastructure/mcp/mcp-openroad.json
@@ -1,10 +1,20 @@
 {
-  "_comment": "OpenROAD MCP server — paste the mcpServers block into your .claude/settings.json",
+  "_comment": "OpenROAD batch MCP server — for single-stage invocations. For ECO iteration queries on a loaded design use mcp-openroad-session.json instead. Replace /absolute/path/to with the actual repo root path.",
   "mcpServers": {
     "openroad": {
       "type": "stdio",
-      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-openroad.sh",
-      "args": []
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-openroad.sh",
+        "--tool", "openroad",
+        "--description", "Run a single OpenROAD stage and return compact JSON: wns_ns, tns_ns, drc_violations, last 5 progress messages"
+      ],
+      "env": {
+        "PDK_ROOT": "/path/to/pdks",
+        "PLATFORM": "sky130hd",
+        "TOOL_TIMEOUT_S": "600"
+      }
     }
   }
 }

--- a/plugins/infrastructure/mcp/mcp-opensta-session.json
+++ b/plugins/infrastructure/mcp/mcp-opensta-session.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "OpenSTA interactive session MCP server — keeps a persistent sta process alive between calls. Exposes load_design, report_timing, report_slack_histogram, check_timing, run_tcl, close_design. Preferred over mcp-opensta.json for multi-corner ECO iteration loops. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "opensta-session": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-session-adapter.py",
+        "--tool", "opensta"
+      ],
+      "env": {
+        "OPENSTA_EXE": "sta",
+        "LIBERTY_PATH": "/path/to/liberty/libs",
+        "SPEF_PATH": "/path/to/spef",
+        "SESSION_TIMEOUT_S": "120",
+        "SESSION_STARTUP_S": "10"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-opensta.json
+++ b/plugins/infrastructure/mcp/mcp-opensta.json
@@ -1,10 +1,20 @@
 {
-  "_comment": "OpenSTA MCP server — paste the mcpServers block into your .claude/settings.json",
+  "_comment": "OpenSTA batch MCP server — for one-shot timing report generation. For multi-corner ECO iteration use mcp-opensta-session.json instead. Replace /absolute/path/to with the actual repo root path.",
   "mcpServers": {
     "opensta": {
       "type": "stdio",
-      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-opensta.sh",
-      "args": []
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-opensta.sh",
+        "--tool", "opensta",
+        "--description", "Run OpenSTA batch timing analysis and return compact JSON: setup/hold WNS, TNS, worst paths"
+      ],
+      "env": {
+        "LIBERTY_PATH": "/path/to/liberty/libs",
+        "SPEF_PATH": "/path/to/spef",
+        "TOOL_TIMEOUT_S": "300"
+      }
     }
   }
 }

--- a/plugins/infrastructure/mcp/mcp-symbiflow.json
+++ b/plugins/infrastructure/mcp/mcp-symbiflow.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "SymbiYosys (sby) batch MCP server — suitable for bounded proof runs and short property checks. Unbounded proofs that may run >1h should be launched via Bash. Replace /absolute/path/to with the actual repo root path.",
+  "_comment": "SymbiYosys (sby) batch MCP server — suitable for bounded proof runs and short property checks. Unbounded proofs that may run >1h should be launched via Bash. The MCP tool name exposed to agents is 'symbiflow'. Replace /absolute/path/to with the actual repo root path.",
   "mcpServers": {
     "symbiflow": {
       "type": "stdio",
@@ -7,11 +7,10 @@
       "args": [
         "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
         "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-symbiflow.sh",
-        "--tool", "symbiyosys",
+        "--tool", "symbiflow",
         "--description", "Run SymbiYosys formal verification and return compact JSON: proved/failed/unknown property lists, counterexample trace path"
       ],
       "env": {
-        "YOSYS_DATDIR": "/usr/share/yosys",
         "SOLVER": "bitwuzla",
         "TOOL_TIMEOUT_S": "3600"
       }

--- a/plugins/infrastructure/mcp/mcp-symbiflow.json
+++ b/plugins/infrastructure/mcp/mcp-symbiflow.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "SymbiYosys (sby) batch MCP server — suitable for bounded proof runs and short property checks. Unbounded proofs that may run >1h should be launched via Bash. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "symbiflow": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-symbiflow.sh",
+        "--tool", "symbiyosys",
+        "--description", "Run SymbiYosys formal verification and return compact JSON: proved/failed/unknown property lists, counterexample trace path"
+      ],
+      "env": {
+        "YOSYS_DATDIR": "/usr/share/yosys",
+        "SOLVER": "bitwuzla",
+        "TOOL_TIMEOUT_S": "3600"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-verilator.json
+++ b/plugins/infrastructure/mcp/mcp-verilator.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Verilator batch MCP server — paste the mcpServers block into your .claude/settings.json. Replace /absolute/path/to with the actual repo root path.",
+  "mcpServers": {
+    "verilator": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-verilator-sim.sh",
+        "--tool", "verilator",
+        "--description", "Run Verilator lint or simulation binary and return compact JSON: test_passed, coverage_pct, error/warning counts"
+      ],
+      "env": {
+        "VERILATOR_ROOT": "/usr/share/verilator",
+        "TOOL_TIMEOUT_S": "300"
+      }
+    }
+  }
+}

--- a/plugins/infrastructure/mcp/mcp-yosys.json
+++ b/plugins/infrastructure/mcp/mcp-yosys.json
@@ -1,10 +1,19 @@
 {
-  "_comment": "Yosys MCP server — paste the mcpServers block into your .claude/settings.json",
+  "_comment": "Yosys batch MCP server — paste the mcpServers block into your .claude/settings.json. Replace /absolute/path/to with the actual repo root path.",
   "mcpServers": {
     "yosys": {
       "type": "stdio",
-      "command": "/absolute/path/to/plugins/infrastructure/tools/wrap-yosys.sh",
-      "args": []
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-adapter.py",
+        "--wrapper", "/absolute/path/to/plugins/infrastructure/tools/wrap-yosys.sh",
+        "--tool", "yosys",
+        "--description", "Run Yosys synthesis and return compact JSON: cells, chip_area_um2, error/warning counts"
+      ],
+      "env": {
+        "YOSYS_DATDIR": "/usr/share/yosys",
+        "TOOL_TIMEOUT_S": "300"
+      }
     }
   }
 }

--- a/plugins/infrastructure/mcp/mcp-yosys.json
+++ b/plugins/infrastructure/mcp/mcp-yosys.json
@@ -11,9 +11,9 @@
         "--description", "Run Yosys synthesis and return compact JSON: cells, chip_area_um2, error/warning counts"
       ],
       "env": {
-        "YOSYS_DATDIR": "/usr/share/yosys",
         "TOOL_TIMEOUT_S": "300"
       }
+
     }
   }
 }

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -67,12 +67,55 @@ complete environment before any domain orchestrator begins work.
 
 ---
 
-## Execution Hierarchy
+## MCP Architecture — Two Tiers
 
-When running tools, prefer in this order:
-1. **MCP server** (lowest overhead, structured output directly in Claude context)
-2. **Wrapper script** (structured JSON output, tool not configured as MCP)
-3. **Direct execution** (last resort — raw log, no structured output)
+### Tier 1: Batch MCP servers (short, self-contained runs)
+Use these for tools whose output fits inside a single request/response cycle (seconds to
+a few minutes).  Each call spawns the wrapper script, captures its compact JSON output,
+and returns it.
+
+| MCP config | Tool | Typical duration |
+|------------|------|-----------------|
+| `mcp-yosys.json` | Yosys synthesis | seconds–minutes |
+| `mcp-openroad.json` | Single OpenROAD stage | minutes |
+| `mcp-opensta.json` | OpenSTA batch report | seconds–minutes |
+| `mcp-klayout.json` | KLayout DRC/LVS | minutes |
+| `mcp-verilator.json` | Verilator lint or sim | seconds–minutes |
+| `mcp-bambu.json` | Bambu HLS synthesis | minutes |
+| `mcp-gem5.json` | gem5 short benchmark run | minutes (set TOOL_TIMEOUT_S) |
+| `mcp-symbiflow.json` | SymbiYosys bounded proof | minutes–hours (set TOOL_TIMEOUT_S) |
+
+The adapter is `plugins/infrastructure/tools/mcp-adapter.py`.
+
+### Tier 2: Interactive session MCP servers (stateful, query-based)
+Use these when an agent iterates many times over an already-loaded design (e.g. ECO timing
+loops).  The process stays alive between calls — no re-loading per query.
+
+| MCP config | Tool | Exposed tools |
+|------------|------|---------------|
+| `mcp-openroad-session.json` | OpenROAD Tcl session | `load_design`, `query_timing`, `query_drc`, `get_design_area`, `get_power`, `run_tcl`, `close_design` |
+| `mcp-opensta-session.json` | OpenSTA Tcl session | `load_design`, `report_timing`, `report_slack_histogram`, `check_timing`, `run_tcl`, `close_design` |
+
+The adapter is `plugins/infrastructure/tools/mcp-session-adapter.py`.
+
+### Full-flow tools — do NOT use MCP
+These tools run for 30 min–2+ hours and produce structured output files on disk.
+Agents must launch them via Bash and read the output files directly.
+
+| Tool | Launch command | Read these files |
+|------|---------------|-----------------|
+| LibreLane / OpenLane 2 | `openlane config.json` | `runs/<design>/<tag>/metrics.json` |
+| ORFS / OpenROAD Flow Scripts | `make DESIGN_CONFIG=... finish` | `reports/<platform>/<design>/metrics.json` |
+| gem5 full-system simulation | `gem5 config.py ...` | `m5out/stats.txt`, `m5out/simout` |
+
+### Execution Hierarchy (per domain agent)
+1. **Tier 2 session MCP** — if the tool supports a session and the design is already loaded
+2. **Tier 1 batch MCP** — if the tool has a batch MCP server configured
+3. **Wrapper script** — if MCP is not configured; wrapper emits compact JSON
+4. **Direct execution** — last resort; raw logs consume significant context
+
+Domain agents must check whether the relevant MCP server is active in `.claude/settings.json`
+before falling back to the wrapper or direct execution.
 
 ---
 
@@ -164,12 +207,16 @@ Fields:
 ## Stage: mcp_configuration
 
 ### Domain Rules
-1. Emit MCP config snippets for OpenROAD, Yosys, and OpenSTA pointing to their wrappers
-2. Config must use `"type": "stdio"` and an absolute path to the wrapper as `command`
-3. Print each snippet with explicit instruction:
+1. Emit MCP config snippets for all 10 MCP configs (8 batch + 2 session)
+2. All batch configs use `"command": "python3"` with `mcp-adapter.py` — never point
+   directly to the wrapper script as the command; wrapper scripts are not MCP servers
+3. Session configs use `mcp-session-adapter.py` with `--tool openroad` or `--tool opensta`
+4. Resolve the absolute adapter and wrapper paths at runtime using `realpath` or `pwd` —
+   never leave the placeholder `/absolute/path/to/` in the emitted snippets
+5. Print each snippet with explicit instruction:
    "Paste the `mcpServers` block into your `.claude/settings.json`"
-4. Write the snippet files to `plugins/infrastructure/mcp/`
-5. Do not modify `.claude/settings.json` automatically — user must do this manually
+6. Write the snippet files to `plugins/infrastructure/mcp/`
+7. Do not modify `.claude/settings.json` automatically — user must do this manually
 
 ### MCP Config Template
 ```json
@@ -185,13 +232,28 @@ Fields:
 ```
 
 ### QoR Metrics to Evaluate
-- `mcp_servers_configured`: count of MCP snippet files written (target: 3)
+- `mcp_servers_configured`: count of MCP snippet files written (target: 10)
 
 ### Output Required
+Batch MCP configs (Tier 1):
 - `plugins/infrastructure/mcp/mcp-yosys.json`
 - `plugins/infrastructure/mcp/mcp-openroad.json`
 - `plugins/infrastructure/mcp/mcp-opensta.json`
-- Printed MCP config snippets for each tool
+- `plugins/infrastructure/mcp/mcp-klayout.json`
+- `plugins/infrastructure/mcp/mcp-verilator.json`
+- `plugins/infrastructure/mcp/mcp-bambu.json`
+- `plugins/infrastructure/mcp/mcp-gem5.json`
+- `plugins/infrastructure/mcp/mcp-symbiflow.json`
+
+Session MCP configs (Tier 2):
+- `plugins/infrastructure/mcp/mcp-openroad-session.json`
+- `plugins/infrastructure/mcp/mcp-opensta-session.json`
+
+Adapter scripts (required — MCP servers will not start without these):
+- `plugins/infrastructure/tools/mcp-adapter.py`
+- `plugins/infrastructure/tools/mcp-session-adapter.py`
+
+Printed MCP config snippets for each tool with resolved absolute paths
 
 ---
 
@@ -209,7 +271,8 @@ Fields:
 - [ ] `install-missing-tools.sh` generated (auto-run is user's choice)
 - [ ] `tool-manifest.json` written
 - [ ] All 8 wrappers deployed and executable
-- [ ] MCP config snippets written and printed
+- [ ] `mcp-adapter.py` and `mcp-session-adapter.py` present in `plugins/infrastructure/tools/`
+- [ ] All 10 MCP config snippets written with resolved absolute paths and printed
 - [ ] No critical-path tools missing
 
 ### Output Required

--- a/plugins/infrastructure/tools/mcp-adapter.py
+++ b/plugins/infrastructure/tools/mcp-adapter.py
@@ -22,6 +22,21 @@ import subprocess
 import argparse
 import os
 import tempfile
+import atexit
+
+# Temp files created for inline Tcl scripts — cleaned up on exit
+_temp_files: list[str] = []
+
+
+def _cleanup_temp_files() -> None:
+    for path in _temp_files:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+atexit.register(_cleanup_temp_files)
 
 # ---------------------------------------------------------------------------
 # MCP protocol helpers
@@ -99,7 +114,7 @@ _EXTRA_PROPERTIES: dict[str, dict] = {
             "description": "Workload binary to simulate (appended after config_script)"
         },
     },
-    "symbiyosys": {
+    "symbiflow": {
         "sby_file": {
             "type": "string",
             "description": "Path to the SymbiYosys .sby configuration file"
@@ -146,6 +161,7 @@ def _build_cli_args(tool: str, inputs: dict) -> list[str]:
             tf.write(inputs["tcl_script"])
             tf.flush()
             tf.close()
+            _temp_files.append(tf.name)
             print(f"[mcp-adapter] wrote Tcl script to {tf.name}", file=sys.stderr)
             return [tf.name] + raw
 
@@ -276,7 +292,15 @@ def main() -> None:
     parser.add_argument("--version", default="1.0.0")
     args = parser.parse_args()
 
-    timeout = int(os.environ.get("TOOL_TIMEOUT_S", "300"))
+    _timeout_raw = os.environ.get("TOOL_TIMEOUT_S", "300")
+    try:
+        timeout = int(_timeout_raw)
+    except ValueError:
+        print(
+            f"[mcp-adapter] WARNING: invalid TOOL_TIMEOUT_S={_timeout_raw!r}, using default 300s",
+            file=sys.stderr,
+        )
+        timeout = 300
     tool_name = args.tool
     wrapper_path = args.wrapper
     description = args.description or (
@@ -302,7 +326,8 @@ def main() -> None:
 
         method: str = req.get("method", "")
         req_id = req.get("id")  # None for notifications
-        params: dict = req.get("params") or {}
+        _raw_params = req.get("params")
+        params: dict = _raw_params if isinstance(_raw_params, dict) else {}
 
         # Notifications have no id — no response required
         if req_id is None:
@@ -331,8 +356,15 @@ def main() -> None:
             }))
 
         elif method == "tools/call":
+            if not isinstance(params, dict):
+                _send(_err(req_id, -32602, "Invalid params: expected object"))
+                continue
             call_name: str = params.get("name", "")
-            call_inputs: dict = params.get("arguments") or {}
+            _raw_args = params.get("arguments")
+            call_inputs: dict = _raw_args if isinstance(_raw_args, dict) else {}
+            if _raw_args is not None and not isinstance(_raw_args, dict):
+                _send(_err(req_id, -32602, "Invalid params: 'arguments' must be an object"))
+                continue
 
             if call_name != tool_name:
                 _send(_err(req_id, -32602, f"Unknown tool '{call_name}'; this server exposes '{tool_name}'"))

--- a/plugins/infrastructure/tools/mcp-adapter.py
+++ b/plugins/infrastructure/tools/mcp-adapter.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+mcp-adapter.py — Generic MCP stdio server wrapping an EDA tool wrapper script.
+
+Implements MCP protocol version 2024-11-05 over stdio (JSON-RPC 2.0, newline-delimited).
+
+Usage:
+    python3 mcp-adapter.py --wrapper /path/to/wrap-TOOL.sh --tool TOOL \\
+        [--description "Short description"] [--version 1.0.0]
+
+Environment:
+    TOOL_TIMEOUT_S   Kill timeout in seconds for the wrapper process (default: 300)
+
+Each tool/call invocation runs the wrapper script with the provided arguments and
+returns its compact JSON output as the MCP tool result.  All debug/status output
+goes to stderr so it does not corrupt the MCP protocol stream on stdout.
+"""
+
+import sys
+import json
+import subprocess
+import argparse
+import os
+import tempfile
+
+# ---------------------------------------------------------------------------
+# MCP protocol helpers
+# ---------------------------------------------------------------------------
+
+def _send(msg: dict) -> None:
+    """Serialise msg as a single JSON line on stdout and flush."""
+    sys.stdout.write(json.dumps(msg, separators=(',', ':')) + '\n')
+    sys.stdout.flush()
+
+
+def _ok(req_id, result: dict) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _err(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+# ---------------------------------------------------------------------------
+# Per-tool input schema and argument builder
+# ---------------------------------------------------------------------------
+
+_EXTRA_PROPERTIES: dict[str, dict] = {
+    "yosys": {
+        "script": {
+            "type": "string",
+            "description": "Inline Yosys commands passed via -p (alternative to args)"
+        },
+        "script_file": {
+            "type": "string",
+            "description": "Path to a .ys script file"
+        },
+    },
+    "openroad": {
+        "tcl_script": {
+            "type": "string",
+            "description": "Inline Tcl script written to a temp file and passed to OpenROAD"
+        },
+    },
+    "opensta": {
+        "tcl_script": {
+            "type": "string",
+            "description": "Inline Tcl script written to a temp file and passed to OpenSTA"
+        },
+    },
+    "verilator": {
+        "mode": {
+            "type": "string",
+            "enum": ["lint", "sim"],
+            "description": "lint: verilator --lint-only; sim: run a pre-compiled sim binary"
+        },
+        "sim_binary": {
+            "type": "string",
+            "description": "Path to compiled Verilator simulation binary (required for sim mode)"
+        },
+    },
+    "bambu": {
+        "c_file": {
+            "type": "string",
+            "description": "Path to the C/C++ source file to synthesise"
+        },
+        "top_function": {
+            "type": "string",
+            "description": "Name of the top-level function to synthesise"
+        },
+    },
+    "gem5": {
+        "config_script": {
+            "type": "string",
+            "description": "Path to the gem5 Python configuration script"
+        },
+        "binary": {
+            "type": "string",
+            "description": "Workload binary to simulate (appended after config_script)"
+        },
+    },
+    "symbiyosys": {
+        "sby_file": {
+            "type": "string",
+            "description": "Path to the SymbiYosys .sby configuration file"
+        },
+        "task": {
+            "type": "string",
+            "description": "Optional task name within the .sby file"
+        },
+    },
+}
+
+
+def _input_schema(tool: str) -> dict:
+    props: dict = {
+        "args": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Raw CLI arguments passed directly to the wrapper script",
+            "default": [],
+        }
+    }
+    props.update(_EXTRA_PROPERTIES.get(tool, {}))
+    return {"type": "object", "properties": props}
+
+
+def _build_cli_args(tool: str, inputs: dict) -> list[str]:
+    """
+    Map structured tool inputs to the CLI argument list that will be passed
+    to the wrapper script.  Falls back to raw args[] if no typed fields match.
+    """
+    raw: list[str] = inputs.get("args", [])
+
+    if tool == "yosys":
+        if "script" in inputs:
+            return ["-p", inputs["script"]] + raw
+        if "script_file" in inputs:
+            return [inputs["script_file"]] + raw
+
+    elif tool in ("openroad", "opensta"):
+        if "tcl_script" in inputs:
+            tf = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".tcl", delete=False, prefix="mcp_tcl_"
+            )
+            tf.write(inputs["tcl_script"])
+            tf.flush()
+            tf.close()
+            print(f"[mcp-adapter] wrote Tcl script to {tf.name}", file=sys.stderr)
+            return [tf.name] + raw
+
+    elif tool == "verilator":
+        mode = inputs.get("mode", "sim")
+        if mode == "lint":
+            return ["--lint-only"] + raw
+        sim_bin = inputs.get("sim_binary", "")
+        if sim_bin:
+            return [sim_bin] + raw
+
+    elif tool == "bambu":
+        cli: list[str] = []
+        if "top_function" in inputs:
+            cli.append("--top-fname=" + inputs["top_function"])
+        cli.extend(raw)
+        if "c_file" in inputs:
+            cli.insert(0, inputs["c_file"])
+        return cli
+
+    elif tool == "gem5":
+        cli = list(raw)
+        if "config_script" in inputs:
+            cli.insert(0, inputs["config_script"])
+        if "binary" in inputs:
+            cli.append(inputs["binary"])
+        return cli
+
+    elif tool in ("symbiyosys", "symbiflow"):
+        cli = list(raw)
+        if "sby_file" in inputs:
+            cli.insert(0, inputs["sby_file"])
+        if "task" in inputs:
+            cli.append(inputs["task"])
+        return cli
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Wrapper execution
+# ---------------------------------------------------------------------------
+
+def _run_wrapper(wrapper_path: str, tool: str, inputs: dict, timeout: int) -> dict:
+    """
+    Execute the wrapper script and return its parsed JSON output.
+    Always returns a dict conforming to the wrapper JSON schema so the
+    caller never has to guard against unexpected shapes.
+    """
+    cli_args = _build_cli_args(tool, inputs)
+    cmd = [wrapper_path] + cli_args
+    print(f"[mcp-adapter] running: {' '.join(cmd)}", file=sys.stderr)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        stdout = proc.stdout.strip()
+
+        if stdout:
+            try:
+                return json.loads(stdout)
+            except json.JSONDecodeError:
+                return {
+                    "tool": tool,
+                    "exit_code": proc.returncode,
+                    "status": "FAIL" if proc.returncode != 0 else "WARN",
+                    "summary": {},
+                    "errors": ["wrapper output was not valid JSON"],
+                    "warnings": [],
+                    "raw_output_excerpt": stdout[:500],
+                }
+        # Empty stdout — surface stderr as the error
+        stderr_snippet = proc.stderr.strip()[:500] if proc.stderr else ""
+        return {
+            "tool": tool,
+            "exit_code": proc.returncode,
+            "status": "FAIL" if proc.returncode != 0 else "PASS",
+            "summary": {},
+            "errors": [stderr_snippet] if stderr_snippet else [],
+            "warnings": [],
+            "raw_log": "",
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "tool": tool,
+            "exit_code": -1,
+            "status": "FAIL",
+            "summary": {},
+            "errors": [
+                f"process timed out after {timeout}s — raise TOOL_TIMEOUT_S env var to allow longer runs"
+            ],
+            "warnings": [],
+            "raw_log": "",
+        }
+
+    except FileNotFoundError:
+        return {
+            "tool": tool,
+            "exit_code": 1,
+            "status": "FAIL",
+            "summary": {},
+            "errors": [f"wrapper script not found: {wrapper_path}"],
+            "warnings": [],
+            "raw_log": "",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Main server loop
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generic MCP stdio adapter for EDA tool wrapper scripts"
+    )
+    parser.add_argument("--wrapper", required=True, help="Absolute path to the wrapper script")
+    parser.add_argument("--tool", required=True, help="Tool name (yosys, openroad, ...)")
+    parser.add_argument(
+        "--description",
+        default="",
+        help="One-line description shown in tools/list",
+    )
+    parser.add_argument("--version", default="1.0.0")
+    args = parser.parse_args()
+
+    timeout = int(os.environ.get("TOOL_TIMEOUT_S", "300"))
+    tool_name = args.tool
+    wrapper_path = args.wrapper
+    description = args.description or (
+        f"Run {tool_name} via output-filtering wrapper; returns compact JSON summary"
+    )
+
+    print(
+        f"[mcp-adapter] starting {tool_name} MCP server "
+        f"(wrapper={wrapper_path}, timeout={timeout}s)",
+        file=sys.stderr,
+    )
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        try:
+            req = json.loads(raw_line)
+        except json.JSONDecodeError:
+            print(f"[mcp-adapter] malformed JSON ignored: {raw_line[:100]}", file=sys.stderr)
+            continue
+
+        method: str = req.get("method", "")
+        req_id = req.get("id")  # None for notifications
+        params: dict = req.get("params") or {}
+
+        # Notifications have no id — no response required
+        if req_id is None:
+            print(f"[mcp-adapter] notification: {method}", file=sys.stderr)
+            continue
+
+        print(f"[mcp-adapter] request id={req_id} method={method}", file=sys.stderr)
+
+        if method == "initialize":
+            _send(_ok(req_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": f"{tool_name}-mcp", "version": args.version},
+            }))
+
+        elif method == "ping":
+            _send(_ok(req_id, {}))
+
+        elif method == "tools/list":
+            _send(_ok(req_id, {
+                "tools": [{
+                    "name": tool_name,
+                    "description": description,
+                    "inputSchema": _input_schema(tool_name),
+                }]
+            }))
+
+        elif method == "tools/call":
+            call_name: str = params.get("name", "")
+            call_inputs: dict = params.get("arguments") or {}
+
+            if call_name != tool_name:
+                _send(_err(req_id, -32602, f"Unknown tool '{call_name}'; this server exposes '{tool_name}'"))
+                continue
+
+            result = _run_wrapper(wrapper_path, tool_name, call_inputs, timeout)
+            _send(_ok(req_id, {
+                "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                "isError": result.get("status") == "FAIL",
+            }))
+
+        else:
+            _send(_err(req_id, -32601, f"Method not found: {method}"))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/infrastructure/tools/mcp-session-adapter.py
+++ b/plugins/infrastructure/tools/mcp-session-adapter.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""
+mcp-session-adapter.py — Persistent MCP stdio server for interactive EDA tool sessions.
+
+Implements MCP protocol version 2024-11-05 over stdio (JSON-RPC 2.0, newline-delimited).
+Keeps a long-lived Tcl subprocess (openroad or sta) open between tool calls, so the
+agent can query timing, DRC, area, etc. on an already-loaded design without re-loading
+on every call.
+
+Usage:
+    python3 mcp-session-adapter.py --tool openroad [--version 1.0.0]
+    python3 mcp-session-adapter.py --tool opensta  [--version 1.0.0]
+
+Environment (openroad):
+    OPENROAD_EXE        openroad executable name or path (default: openroad)
+    PDK_ROOT            path to PDK root (used in load_design defaults)
+    PLATFORM            PDK platform name e.g. sky130hd
+
+Environment (opensta):
+    OPENSTA_EXE         sta executable name or path (default: sta)
+    LIBERTY_PATH        default directory for .lib files
+    SPEF_PATH           default directory for .spef files
+
+Environment (both):
+    SESSION_TIMEOUT_S   per-command timeout in seconds (default: 120)
+    SESSION_STARTUP_S   startup drain timeout in seconds (default: 10)
+"""
+
+import sys
+import json
+import subprocess
+import argparse
+import os
+import re
+import time
+import threading
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Protocol helpers
+# ---------------------------------------------------------------------------
+
+def _send(msg: dict) -> None:
+    sys.stdout.write(json.dumps(msg, separators=(',', ':')) + '\n')
+    sys.stdout.flush()
+
+
+def _ok(req_id, result: dict) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _err(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def _log(msg: str) -> None:
+    print(f"[mcp-session] {msg}", file=sys.stderr, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Tcl session
+# ---------------------------------------------------------------------------
+
+_SENTINEL = "<<MCP_SESSION_DONE>>"
+
+
+class TclSession:
+    """
+    Wraps a long-lived Tcl-based EDA process (openroad / sta).
+
+    Commands are sent via stdin; output is collected until the sentinel line
+    appears.  stderr is merged into stdout so error messages are captured.
+    """
+
+    def __init__(self, exe: str, startup_timeout: int = 10):
+        self._proc = subprocess.Popen(
+            [exe],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,          # line-buffered
+        )
+        self._lock = threading.Lock()
+        self._alive = True
+        # Drain any startup banner
+        self._drain_startup(startup_timeout)
+        _log(f"session started (pid={self._proc.pid})")
+
+    def _drain_startup(self, timeout: int) -> None:
+        """
+        Discard any startup banner by sending the sentinel immediately
+        and collecting until it echoes back.
+        """
+        self._proc.stdin.write(f'puts "{_SENTINEL}"\n')
+        self._proc.stdin.flush()
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            line = self._proc.stdout.readline()
+            if not line or line.rstrip('\n') == _SENTINEL:
+                break
+
+    def run(self, tcl: str, timeout: int = 120) -> tuple[list[str], bool]:
+        """
+        Send Tcl commands and collect output until the sentinel.
+
+        Returns (lines, had_error).  Thread-safe.
+        """
+        if not self._alive:
+            return ["session is closed"], True
+
+        with self._lock:
+            script = tcl.strip() + f'\nputs "{_SENTINEL}"\n'
+            try:
+                self._proc.stdin.write(script)
+                self._proc.stdin.flush()
+            except BrokenPipeError:
+                self._alive = False
+                return ["session process died (broken pipe)"], True
+
+            lines: list[str] = []
+            had_error = False
+            deadline = time.time() + timeout
+
+            while time.time() < deadline:
+                # Non-blocking read with a short poll
+                line = self._proc.stdout.readline()
+                if not line:
+                    self._alive = False
+                    had_error = True
+                    lines.append("session process exited unexpectedly")
+                    break
+                stripped = line.rstrip('\n')
+                if stripped == _SENTINEL:
+                    break
+                lines.append(stripped)
+                if re.search(r'\[ERROR\]|^Error\b|^error\b', stripped):
+                    had_error = True
+
+            return lines, had_error
+
+    def is_alive(self) -> bool:
+        if not self._alive:
+            return False
+        if self._proc.poll() is not None:
+            self._alive = False
+        return self._alive
+
+    def close(self) -> None:
+        if not self._alive:
+            return
+        try:
+            self._proc.stdin.write("exit\n")
+            self._proc.stdin.flush()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+        self._alive = False
+        _log("session closed")
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _parse_timing(lines: list[str]) -> dict:
+    """Extract WNS, TNS, and worst slack paths from report_timing output."""
+    text = '\n'.join(lines)
+    result: dict = {}
+
+    wns_m = re.search(r'wns\s+([-\d.]+)', text)
+    tns_m = re.search(r'tns\s+([-\d.]+)', text)
+    if wns_m:
+        result["setup_wns_ns"] = float(wns_m.group(1))
+    if tns_m:
+        result["setup_tns_ps"] = float(tns_m.group(1))
+
+    # Hold metrics
+    hold_wns_m = re.search(r'hold\s+wns\s+([-\d.]+)', text, re.I)
+    hold_tns_m = re.search(r'hold\s+tns\s+([-\d.]+)', text, re.I)
+    if hold_wns_m:
+        result["hold_wns_ps"] = float(hold_wns_m.group(1))
+    if hold_tns_m:
+        result["hold_tns_ps"] = float(hold_tns_m.group(1))
+
+    # Worst path endpoint names
+    endpoints = re.findall(r'Endpoint\s*:\s*(\S+)', text)
+    if endpoints:
+        result["worst_endpoints"] = endpoints[:5]
+
+    slack_m = re.findall(r'slack\s+\((?:MET|VIOLATED)\)\s+([-\d.]+)', text)
+    if slack_m:
+        result["worst_slack_ns"] = float(slack_m[0])
+
+    result["raw_lines"] = len(lines)
+    return result
+
+
+def _parse_drc(lines: list[str]) -> dict:
+    """Extract DRC violation counts from check_drc / report_drc output."""
+    text = '\n'.join(lines)
+    result: dict = {}
+    total_m = re.search(r'(\d+)\s+(?:DRC\s+)?(?:violations?|errors?)', text, re.I)
+    if total_m:
+        result["drc_total"] = int(total_m.group(1))
+    else:
+        result["drc_total"] = 0
+
+    cats: dict = {}
+    for m in re.finditer(r'(\w[\w\s]*?)\s*:\s*(\d+)\s*violations?', text, re.I):
+        cats[m.group(1).strip()] = int(m.group(2))
+    if cats:
+        result["drc_categories"] = cats
+
+    result["raw_lines"] = len(lines)
+    return result
+
+
+def _parse_area(lines: list[str]) -> dict:
+    """Extract area and utilisation from report_design_area output."""
+    text = '\n'.join(lines)
+    result: dict = {}
+    area_m = re.search(r'Design area\s+([\d.]+)\s+u\^2\s+([\d.]+)%', text)
+    if area_m:
+        result["area_um2"] = float(area_m.group(1))
+        result["utilisation_pct"] = float(area_m.group(2))
+    result["raw_lines"] = len(lines)
+    return result
+
+
+def _parse_power(lines: list[str]) -> dict:
+    """Extract power summary from report_power output."""
+    text = '\n'.join(lines)
+    result: dict = {}
+    total_m = re.search(r'Total\s+([\d.e+\-]+)\s+([\d.e+\-]+)\s+([\d.e+\-]+)\s+([\d.e+\-]+)', text)
+    if total_m:
+        result["internal_power_W"] = float(total_m.group(1))
+        result["switching_power_W"] = float(total_m.group(2))
+        result["leakage_power_W"]   = float(total_m.group(3))
+        result["total_power_W"]     = float(total_m.group(4))
+    result["raw_lines"] = len(lines)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions per session type
+# ---------------------------------------------------------------------------
+
+_TOOLS_OPENROAD = [
+    {
+        "name": "load_design",
+        "description": "Load an OpenROAD design database (.odb/.db) into the session",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "db_path": {
+                    "type": "string",
+                    "description": "Absolute path to the .odb or .db file"
+                }
+            },
+            "required": ["db_path"],
+        },
+    },
+    {
+        "name": "query_timing",
+        "description": "Report setup/hold timing summary: WNS, TNS, worst endpoints",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path_count": {
+                    "type": "integer",
+                    "default": 5,
+                    "description": "Number of worst paths to report (default: 5)"
+                },
+                "path_type": {
+                    "type": "string",
+                    "enum": ["setup", "hold", "both"],
+                    "default": "setup",
+                    "description": "Timing check type to report"
+                },
+            },
+        },
+    },
+    {
+        "name": "query_drc",
+        "description": "Run DRC check and return total violation count and per-category breakdown",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_design_area",
+        "description": "Return core area (um²) and utilisation percentage",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_power",
+        "description": "Return power breakdown: internal, switching, leakage, total (Watts)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "run_tcl",
+        "description": "Execute arbitrary Tcl in the OpenROAD session and return raw output lines",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Tcl script to execute"
+                },
+                "timeout_s": {
+                    "type": "integer",
+                    "description": "Per-command timeout override in seconds"
+                },
+            },
+            "required": ["script"],
+        },
+    },
+    {
+        "name": "close_design",
+        "description": "Reset the OpenROAD session (clears loaded design; session stays alive)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+_TOOLS_OPENSTA = [
+    {
+        "name": "load_design",
+        "description": "Load a gate-level netlist, liberty, SDC, and optionally parasitics into OpenSTA",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "netlist": {
+                    "type": "string",
+                    "description": "Path to gate-level Verilog netlist"
+                },
+                "sdc": {
+                    "type": "string",
+                    "description": "Path to SDC constraints file"
+                },
+                "liberty_files": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Paths to .lib liberty files (supplements LIBERTY_PATH env)"
+                },
+                "spef": {
+                    "type": "string",
+                    "description": "Path to .spef parasitics file (optional)"
+                },
+                "top_module": {
+                    "type": "string",
+                    "description": "Name of the top-level module to link"
+                },
+            },
+            "required": ["netlist", "sdc"],
+        },
+    },
+    {
+        "name": "report_timing",
+        "description": "Report setup/hold timing: WNS, TNS, worst slack paths per corner",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path_count": {
+                    "type": "integer",
+                    "default": 5,
+                    "description": "Number of worst paths (default: 5)"
+                },
+                "path_type": {
+                    "type": "string",
+                    "enum": ["max", "min", "both"],
+                    "default": "max",
+                    "description": "max=setup, min=hold"
+                },
+                "corner": {
+                    "type": "string",
+                    "description": "Specific corner name; omit for all corners"
+                },
+            },
+        },
+    },
+    {
+        "name": "report_slack_histogram",
+        "description": "Return a slack distribution histogram across all endpoints",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "bins": {
+                    "type": "integer",
+                    "default": 10,
+                    "description": "Number of histogram bins"
+                }
+            },
+        },
+    },
+    {
+        "name": "check_timing",
+        "description": "Report unconstrained paths, multi-driven nets, and missing constraints",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "run_tcl",
+        "description": "Execute arbitrary Tcl in the OpenSTA session and return raw output lines",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Tcl script to execute"
+                },
+                "timeout_s": {
+                    "type": "integer",
+                    "description": "Per-command timeout override in seconds"
+                },
+            },
+            "required": ["script"],
+        },
+    },
+    {
+        "name": "close_design",
+        "description": "Reset the OpenSTA session (clears loaded design; session stays alive)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+def _dispatch_openroad(
+    session: TclSession, tool_name: str, inputs: dict, timeout: int
+) -> dict:
+    if tool_name == "load_design":
+        db = inputs["db_path"]
+        lines, err = session.run(f'read_db {{{db}}}', timeout)
+        return {"loaded": not err, "db_path": db, "messages": lines[:20], "had_error": err}
+
+    elif tool_name == "query_timing":
+        n = inputs.get("path_count", 5)
+        pt = inputs.get("path_type", "setup")
+        if pt == "both":
+            tcl = (
+                f'report_timing -path_type summary -nworst {n}\n'
+                f'report_timing -path_type summary -nworst {n} -hold'
+            )
+        elif pt == "hold":
+            tcl = f'report_timing -path_type summary -nworst {n} -hold'
+        else:
+            tcl = f'report_timing -path_type summary -nworst {n}'
+        lines, err = session.run(tcl, timeout)
+        parsed = _parse_timing(lines)
+        parsed["had_error"] = err
+        return parsed
+
+    elif tool_name == "query_drc":
+        lines, err = session.run('check_drc', timeout)
+        parsed = _parse_drc(lines)
+        parsed["had_error"] = err
+        return parsed
+
+    elif tool_name == "get_design_area":
+        lines, err = session.run('report_design_area', timeout)
+        parsed = _parse_area(lines)
+        parsed["had_error"] = err
+        return parsed
+
+    elif tool_name == "get_power":
+        lines, err = session.run('report_power', timeout)
+        parsed = _parse_power(lines)
+        parsed["had_error"] = err
+        return parsed
+
+    elif tool_name == "run_tcl":
+        script = inputs["script"]
+        t = inputs.get("timeout_s", timeout)
+        lines, err = session.run(script, t)
+        return {"output_lines": lines, "had_error": err, "line_count": len(lines)}
+
+    elif tool_name == "close_design":
+        lines, err = session.run('delete_db', timeout)
+        return {"reset": True, "messages": lines[:10], "had_error": err}
+
+    return {"error": f"unknown tool: {tool_name}"}
+
+
+def _dispatch_opensta(
+    session: TclSession, tool_name: str, inputs: dict, timeout: int
+) -> dict:
+    if tool_name == "load_design":
+        tcl_parts: list[str] = []
+
+        # Liberty files from env + input
+        liberty_dir = os.environ.get("LIBERTY_PATH", "")
+        for lib in inputs.get("liberty_files", []):
+            tcl_parts.append(f'read_liberty {{{lib}}}')
+        if liberty_dir and not inputs.get("liberty_files"):
+            tcl_parts.append(f'foreach f [glob -nocomplain {{{liberty_dir}}}/*.lib] {{ read_liberty $f }}')
+
+        tcl_parts.append(f'read_verilog {{{inputs["netlist"]}}}')
+        top = inputs.get("top_module", "")
+        tcl_parts.append(f'link_design {top}' if top else 'link_design')
+        tcl_parts.append(f'read_sdc {{{inputs["sdc"]}}}')
+
+        spef = inputs.get("spef") or os.environ.get("SPEF_PATH", "")
+        if spef:
+            tcl_parts.append(f'read_parasitics {{{spef}}}')
+
+        lines, err = session.run('\n'.join(tcl_parts), timeout)
+        return {"loaded": not err, "messages": lines[:20], "had_error": err}
+
+    elif tool_name == "report_timing":
+        n = inputs.get("path_count", 5)
+        pt = inputs.get("path_type", "max")
+        corner = inputs.get("corner", "")
+        corner_flag = f'-corner {corner}' if corner else ''
+        if pt == "both":
+            tcl = (
+                f'report_timing -path_type summary -nworst {n} {corner_flag}\n'
+                f'report_timing -path_type summary -nworst {n} -path_type min {corner_flag}'
+            )
+        else:
+            path_flag = '-path_type min' if pt == "min" else ''
+            tcl = f'report_timing -path_type summary -nworst {n} {path_flag} {corner_flag}'
+        lines, err = session.run(tcl, timeout)
+        parsed = _parse_timing(lines)
+        parsed["had_error"] = err
+        return parsed
+
+    elif tool_name == "report_slack_histogram":
+        bins = inputs.get("bins", 10)
+        lines, err = session.run(f'report_slack_histogram -digits 3 -bins {bins}', timeout)
+        text = '\n'.join(lines)
+        buckets: list[dict] = []
+        for m in re.finditer(r'([-\d.]+)\s+([-\d.]+)\s+(\d+)', text):
+            buckets.append({
+                "slack_low_ns": float(m.group(1)),
+                "slack_high_ns": float(m.group(2)),
+                "count": int(m.group(3)),
+            })
+        return {"buckets": buckets, "had_error": err, "raw_lines": len(lines)}
+
+    elif tool_name == "check_timing":
+        lines, err = session.run('check_timing', timeout)
+        text = '\n'.join(lines)
+        unconstrained = len(re.findall(r'unconstrained', text, re.I))
+        multi_driven  = len(re.findall(r'multiple.driven|multi.driven', text, re.I))
+        return {
+            "unconstrained_endpoints": unconstrained,
+            "multi_driven_nets": multi_driven,
+            "output_lines": lines[:30],
+            "had_error": err,
+        }
+
+    elif tool_name == "run_tcl":
+        script = inputs["script"]
+        t = inputs.get("timeout_s", timeout)
+        lines, err = session.run(script, t)
+        return {"output_lines": lines, "had_error": err, "line_count": len(lines)}
+
+    elif tool_name == "close_design":
+        lines, err = session.run('remove_design', timeout)
+        return {"reset": True, "messages": lines[:10], "had_error": err}
+
+    return {"error": f"unknown tool: {tool_name}"}
+
+
+# ---------------------------------------------------------------------------
+# Main server loop
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Persistent MCP stdio session adapter for OpenROAD / OpenSTA"
+    )
+    parser.add_argument(
+        "--tool",
+        required=True,
+        choices=["openroad", "opensta"],
+        help="Which tool to manage: openroad or opensta",
+    )
+    parser.add_argument("--version", default="1.0.0")
+    args = parser.parse_args()
+
+    tool_type = args.tool
+    cmd_timeout = int(os.environ.get("SESSION_TIMEOUT_S", "120"))
+    startup_timeout = int(os.environ.get("SESSION_STARTUP_S", "10"))
+
+    if tool_type == "openroad":
+        exe = os.environ.get("OPENROAD_EXE", "openroad")
+        tools_list = _TOOLS_OPENROAD
+        server_name = "openroad-session-mcp"
+    else:
+        exe = os.environ.get("OPENSTA_EXE", "sta")
+        tools_list = _TOOLS_OPENSTA
+        server_name = "opensta-session-mcp"
+
+    session: Optional[TclSession] = None
+
+    def _get_session() -> TclSession:
+        nonlocal session
+        if session is None or not session.is_alive():
+            _log(f"(re)starting {tool_type} session with: {exe}")
+            session = TclSession(exe, startup_timeout)
+        return session
+
+    _log(f"starting {server_name} (exe={exe}, cmd_timeout={cmd_timeout}s)")
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        try:
+            req = json.loads(raw_line)
+        except json.JSONDecodeError:
+            _log(f"malformed JSON ignored: {raw_line[:80]}")
+            continue
+
+        method: str = req.get("method", "")
+        req_id = req.get("id")
+        params: dict = req.get("params") or {}
+
+        if req_id is None:
+            _log(f"notification: {method}")
+            continue
+
+        _log(f"request id={req_id} method={method}")
+
+        if method == "initialize":
+            _send(_ok(req_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": server_name, "version": args.version},
+            }))
+
+        elif method == "ping":
+            _send(_ok(req_id, {}))
+
+        elif method == "tools/list":
+            _send(_ok(req_id, {"tools": tools_list}))
+
+        elif method == "tools/call":
+            call_name: str = params.get("name", "")
+            call_inputs: dict = params.get("arguments") or {}
+
+            known = {t["name"] for t in tools_list}
+            if call_name not in known:
+                _send(_err(req_id, -32602, f"Unknown tool '{call_name}'"))
+                continue
+
+            try:
+                sess = _get_session()
+                if tool_type == "openroad":
+                    result = _dispatch_openroad(sess, call_name, call_inputs, cmd_timeout)
+                else:
+                    result = _dispatch_opensta(sess, call_name, call_inputs, cmd_timeout)
+            except Exception as exc:
+                _log(f"dispatch error: {exc}")
+                result = {"had_error": True, "error": str(exc)}
+
+            is_error = result.get("had_error", False)
+            _send(_ok(req_id, {
+                "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                "isError": is_error,
+            }))
+
+        else:
+            _send(_err(req_id, -32601, f"Method not found: {method}"))
+
+    # Clean up session on EOF
+    if session and session.is_alive():
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/infrastructure/tools/mcp-session-adapter.py
+++ b/plugins/infrastructure/tools/mcp-session-adapter.py
@@ -19,7 +19,7 @@ Environment (openroad):
 Environment (opensta):
     OPENSTA_EXE         sta executable name or path (default: sta)
     LIBERTY_PATH        default directory for .lib files
-    SPEF_PATH           default directory for .spef files
+    SPEF_PATH           full path to the .spef parasitics file (not a directory); passed directly to read_parasitics
 
 Environment (both):
     SESSION_TIMEOUT_S   per-command timeout in seconds (default: 120)
@@ -32,9 +32,28 @@ import subprocess
 import argparse
 import os
 import re
+import select
 import time
 import threading
 from typing import Optional
+
+
+def _readline_timed(stream, deadline: float) -> str:
+    """
+    Read one line from stream, returning '' if the deadline passes before
+    a line arrives.  Uses select(2) so the calling thread is not blocked
+    beyond the remaining time budget.
+
+    Note: select on file objects is POSIX-only (Linux/macOS).  These wrapper
+    scripts target Linux EDA environments; Windows is not supported.
+    """
+    remaining = deadline - time.time()
+    if remaining <= 0:
+        return ''
+    ready, _, _ = select.select([stream], [], [], remaining)
+    if not ready:
+        return ''
+    return stream.readline()
 
 # ---------------------------------------------------------------------------
 # Protocol helpers
@@ -90,13 +109,13 @@ class TclSession:
     def _drain_startup(self, timeout: int) -> None:
         """
         Discard any startup banner by sending the sentinel immediately
-        and collecting until it echoes back.
+        and collecting until it echoes back.  Respects timeout via select.
         """
         self._proc.stdin.write(f'puts "{_SENTINEL}"\n')
         self._proc.stdin.flush()
         deadline = time.time() + timeout
-        while time.time() < deadline:
-            line = self._proc.stdout.readline()
+        while True:
+            line = _readline_timed(self._proc.stdout, deadline)
             if not line or line.rstrip('\n') == _SENTINEL:
                 break
 
@@ -122,13 +141,22 @@ class TclSession:
             had_error = False
             deadline = time.time() + timeout
 
-            while time.time() < deadline:
-                # Non-blocking read with a short poll
-                line = self._proc.stdout.readline()
-                if not line:
-                    self._alive = False
-                    had_error = True
-                    lines.append("session process exited unexpectedly")
+            while True:
+                line = _readline_timed(self._proc.stdout, deadline)
+                if line == '':
+                    # '' means either deadline passed (select timeout) or EOF
+                    if self._proc.poll() is not None:
+                        self._alive = False
+                        had_error = True
+                        lines.append("session process exited unexpectedly")
+                    else:
+                        had_error = True
+                        lines.append(f"command timed out after {timeout}s")
+                        try:
+                            self._proc.kill()
+                        except OSError:
+                            pass
+                        self._alive = False
                     break
                 stripped = line.rstrip('\n')
                 if stripped == _SENTINEL:
@@ -176,15 +204,15 @@ def _parse_timing(lines: list[str]) -> dict:
     if wns_m:
         result["setup_wns_ns"] = float(wns_m.group(1))
     if tns_m:
-        result["setup_tns_ps"] = float(tns_m.group(1))
+        result["setup_tns_ns"] = float(tns_m.group(1))
 
     # Hold metrics
     hold_wns_m = re.search(r'hold\s+wns\s+([-\d.]+)', text, re.I)
     hold_tns_m = re.search(r'hold\s+tns\s+([-\d.]+)', text, re.I)
     if hold_wns_m:
-        result["hold_wns_ps"] = float(hold_wns_m.group(1))
+        result["hold_wns_ns"] = float(hold_wns_m.group(1))
     if hold_tns_m:
-        result["hold_tns_ps"] = float(hold_tns_m.group(1))
+        result["hold_tns_ns"] = float(hold_tns_m.group(1))
 
     # Worst path endpoint names
     endpoints = re.findall(r'Endpoint\s*:\s*(\S+)', text)

--- a/plugins/infrastructure/tools/wrap-symbiflow.sh
+++ b/plugins/infrastructure/tools/wrap-symbiflow.sh
@@ -7,7 +7,7 @@ TOOL="sby"
 if ! command -v "$TOOL" &>/dev/null; then
   python3 - <<'PYEOF'
 import json
-print(json.dumps({"tool":"symbiyosys","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: sby (SymbiYosys)"],"warnings":[],"raw_log":""}))
+print(json.dumps({"tool":"symbiflow","exit_code":1,"status":"FAIL","summary":{},"errors":["tool not found: sby (SymbiYosys)"],"warnings":[],"raw_log":""}))
 PYEOF
   exit 1
 fi
@@ -58,7 +58,7 @@ else:
     status = "PASS"
 
 print(json.dumps({
-    "tool":      "symbiyosys",
+    "tool":      "symbiflow",
     "exit_code": exit_code,
     "status":    status,
     "summary":   summary,

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -29,6 +29,19 @@ floorplan → placement → cts → routing → timing_optimization → power_op
 - Synopsys IC Compiler 2 (`icc2_shell`)
 - Siemens Aprisa
 
+### MCP Preference
+Full ORFS / LibreLane flows are **not** run via MCP — they are long-running and produce
+structured output files.  After `make ... finish` or `openlane config.json` completes,
+read `reports/.../metrics.json` (ORFS) or `runs/<design>/<tag>/metrics.json` (LibreLane).
+
+For ECO iteration loops (timing_optimization, signoff stages) where the design is already
+placed/routed, prefer:
+1. **`openroad-session` MCP** (Tier 2) — call `load_design`, then `query_timing` / `query_drc`
+   repeatedly without reloading; lowest overhead per ECO iteration
+2. **`openroad` batch MCP** (Tier 1) — for one-shot single-stage invocations
+3. **Wrapper script** — `wrap-openroad.sh` / `wrap-klayout.sh` if MCP not configured
+4. **Direct execution** — last resort
+
 ## Loop-Back Rules
 - placement FAIL (WNS < −0.5 ns)              → floorplan             (max 2×)
 - routing FAIL (DRC violations > 0)            → routing               (max 3×)

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -31,6 +31,12 @@ module_planning → rtl_coding → lint_check → cdc_rdc_analysis → synth_che
 - Cadence JasperGold CDC (`jg`)
 - Siemens Questa CDC (`vsim`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `verilator` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-verilator-sim.sh` (structured JSON with lint error/warning counts)
+3. **Direct execution** — last resort; Verilator lint output accumulates quickly across loop-back iterations
+
 ## Loop-Back Rules
 - lint_check FAIL (errors > 0)               → rtl_coding        (max 5×)
 - cdc_rdc_analysis FAIL (unwaived violations) → rtl_coding        (max 3×)

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -30,6 +30,12 @@ ip_procurement → ip_configuration → bus_fabric_setup → top_integration →
 - Cadence Xcelium (`xrun`)
 - Siemens Questa (`vsim`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `verilator` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-verilator-sim.sh` (structured JSON with pass/fail and coverage)
+3. **Direct execution** — last resort; chip-level simulation logs are very large
+
 ## Loop-Back Rules
 - ip_configuration FAIL (timing/interface error)  → ip_procurement    (max 2×)
 - top_integration FAIL (connectivity errors)       → top_integration   (max 3×)

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -27,6 +27,20 @@ constraint_validation → multi_corner_analysis → path_analysis → exception_
 - Synopsys PrimeTime (`pt_shell`)
 - Cadence Tempus (`tempus`)
 
+### MCP Preference
+Multi-corner ECO loops query timing repeatedly on the same loaded design — this is the
+highest-value MCP use case in the entire flow.
+
+1. **`opensta-session` MCP** (Tier 2, preferred) — call `load_design` once, then
+   `report_timing` / `report_slack_histogram` / `check_timing` per ECO iteration without
+   reloading liberty or parasitics; critical for the `eco_guidance → multi_corner_analysis`
+   loop which can iterate up to 10 times
+2. **`openroad-session` MCP** (Tier 2) — when using the OpenROAD STA subsystem on a
+   loaded PD database
+3. **`opensta` batch MCP** (Tier 1) — for one-shot report generation (no active ECO loop)
+4. **Wrapper script** — `wrap-opensta.sh` / `wrap-openroad.sh` if MCP not configured
+5. **Direct execution** — last resort; multi-corner timing reports are extremely large
+
 ## Loop-Back Rules
 - path_analysis: violations found             → exception_review       (unlimited)
 - exception_review: invalid exceptions       → path_analysis          (max 3×)

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -29,6 +29,12 @@ constraint_setup → compile_explore → compile_final → netlist_qc → synthe
 - Cadence Genus (`genus`)
 - Synopsys Fusion Compiler (`fc_shell`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `yosys` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `plugins/infrastructure/tools/wrap-yosys.sh` (structured JSON output)
+3. **Direct execution** — last resort; raw logs will consume significant context
+
 ## Loop-Back Rules
 - compile_final FAIL (WNS < 0)          → compile_final    (max 3×)
 - compile_final FAIL (area > budget)    → compile_explore  (max 2×)

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -30,6 +30,12 @@ tb_architecture → test_planning → uvm_tb_build → directed_tests → constr
 - Cadence Xcelium (`xrun`)
 - Siemens Questa (`vsim` / `vlog` / `vcom`)
 
+### MCP Preference
+When invoking open-source tools, follow the execution hierarchy:
+1. **MCP server** — use `verilator` MCP if active in `.claude/settings.json` (lowest context overhead)
+2. **Wrapper script** — `wrap-verilator-sim.sh` (structured JSON with coverage and pass/fail)
+3. **Direct execution** — last resort; simulation logs and coverage data are very large
+
 ## Loop-Back Rules
 - uvm_tb_build FAIL (build errors)                  → uvm_tb_build       (max 3×)
 - directed_tests: DUT bug found                     → SUSPEND; flag RTL fix needed


### PR DESCRIPTION
- Add tool-based MCP for agents to use to reduce irrelevant information parsed
- Full-flow tools such as OpenLane/OpenROAD/Librelane will not use MCP due to long run time across many different tool-uses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added MCP server configurations for common EDA tools, enabling structured execution with automatic fallback paths.
  * Introduced two-tier MCP architecture: batch servers for single operations and session servers for persistent, multi-step workflows.
  * Configured intelligent tool execution hierarchies across orchestrators to prefer MCP when available, with graceful fallbacks.

* **Documentation**
  * Updated infrastructure guide documenting new two-tier MCP architecture and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->