### PR TITLE
[Feature] Add two-tier agent memory system across all domain orchestrators

### DIFF
--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -1,0 +1,50 @@
+# Future Work
+
+Items deferred from the two-tier agent memory system implementation (see `memory/README.md`).
+Track these as follow-up issues after the initial memory system ships.
+
+## 1. Memory-Keeper Skill
+
+A skill (or infrastructure stage) that periodically distills `memory/<domain>/experiences.jsonl`
+into an updated `memory/<domain>/knowledge.md` summary. Without this, the knowledge file stays at
+its seeded content while experience records accumulate. The skill should:
+
+- Read all records in `experiences.jsonl` for a domain
+- Extract recurring issues, successful fixes, and tool flag patterns
+- Update the `knowledge.md` with distilled learnings, preserving existing content that is still accurate
+- Be invocable manually or on a schedule (e.g., after every 10 runs)
+
+## 2. Semantic Search Over Experiences
+
+An MCP memory server that embeds experience records and allows orchestrators to query by similarity
+(e.g., "what fixed WNS issues on sky130 before?") rather than full-file read.
+
+**Prerequisite**: Experience log must be large enough to justify the infrastructure overhead —
+target threshold is ~50 records per domain before semantic search adds value over keyword grep.
+
+Implementation options:
+- SQLite + sqlite-vec extension (zero-dependency, file-based)
+- Chroma or Qdrant (local Docker container)
+- Hosted: Pinecone, Weaviate Cloud
+
+## 3. Cross-Design Metric Trending
+
+A reporting utility or dashboard that reads all `memory/<domain>/experiences.jsonl` files and
+plots QoR trends (WNS, area, coverage) across runs for a named design. Use cases:
+
+- Regression detection: alert when a metric degrades across runs
+- PDK comparison: compare WNS/area across sky130 vs GF180 for the same RTL
+- Tool comparison: compare Yosys vs DC synthesis area for the same design
+
+Implementation: Python script + matplotlib, or a Jupyter notebook in `tools/qor_trends.ipynb`.
+
+## 4. Infrastructure Orchestrator Memory
+
+Track tool versions, install paths, and MCP configuration choices across setups in
+`memory/infrastructure/`. Deferred because:
+
+- Infrastructure state is environment-specific (machine A ≠ machine B)
+- The value is lower than domain memory — tool version is better tracked in a lockfile
+- MCP configuration is already stored in `.claude/settings.json`
+
+Revisit if tool version mismatches cause repeated debugging across sessions.

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,86 @@
+# Agent Memory System
+
+This directory holds persistent, file-based memory for the digital chip design orchestrators.
+Agents read it at session start and write to it at session end — no new infrastructure required.
+
+## Two-Tier Design
+
+### Tier 1 — `experiences.jsonl`
+Append-only JSONL file. One record per completed (or abandoned) orchestrator run.
+Machine-parseable; grows over time; never edited manually.
+
+### Tier 2 — `knowledge.md`
+Human- and agent-readable distilled summary. Seeded with known failure patterns, successful
+tool flags, and PDK/tool quirks. Intended to be periodically updated by a memory-keeper skill
+(see `FUTURE_WORK.md`) as experience records accumulate.
+
+## Experience Record Schema
+
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "<domain>",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": { "<domain-specific fields — see table below>" },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+
+## Domain key_metrics Fields
+
+| Domain       | key_metrics fields                                                    |
+|--------------|-----------------------------------------------------------------------|
+| architecture | `selected_arch`, `estimated_mhz`, `estimated_area_um2`              |
+| compiler     | `isa_tests_passed`, `abi_compliant`, `regression_pass_rate`          |
+| dft          | `scan_coverage_pct`, `atpg_fault_coverage_pct`                       |
+| firmware     | `build_pass`, `flash_size_kb`, `bsp_tests_passed`                    |
+| formal       | `proved`, `failed`, `unknown`                                         |
+| fpga         | `lut_count`, `fmax_mhz`, `timing_met`                                |
+| hls          | `latency_cycles`, `dsp_count`, `ii_achieved`                         |
+| pd           | `wns_ns`, `drc_violations`, `lvs_errors`, `gds_area_um2`            |
+| rtl-design   | `lint_errors`, `cdc_violations`, `synth_check_pass`                  |
+| soc          | `ip_blocks_integrated`, `simulation_pass`, `memory_map_conflicts`    |
+| sta          | `setup_wns_ns`, `hold_wns_ns`, `tns_ns`, `failing_paths`            |
+| synthesis    | `wns_ns`, `cells`, `area_um2`, `lec_unmatched`                       |
+| verification | `functional_coverage_pct`, `regression_failures`, `assertions_triggered` |
+
+## Directory Layout
+
+```
+memory/
+├── README.md                    ← this file
+├── designs/                     ← per-design metric history (future use)
+│   └── .gitkeep
+├── architecture/
+│   ├── knowledge.md             ← Tier 2: seeded domain knowledge
+│   └── experiences.jsonl        ← Tier 1: created on first run
+├── compiler/
+├── dft/
+├── firmware/
+├── formal/
+├── fpga/
+├── hls/
+├── pd/
+├── rtl-design/
+├── soc/
+├── sta/
+├── synthesis/
+└── verification/
+```
+
+## How Orchestrators Use This
+
+**Session start**: Read `memory/<domain>/knowledge.md` before the first stage.
+Incorporate guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes.
+
+**Session end**: After signoff (or on escalation/abandon), append one JSON line to
+`memory/<domain>/experiences.jsonl`. Create the file and parent directories if they
+do not exist.

--- a/memory/architecture/knowledge.md
+++ b/memory/architecture/knowledge.md
@@ -1,0 +1,34 @@
+# Architecture Domain Knowledge
+
+## Known Failure Patterns
+
+- **Incomplete spec → HIGH risk_assessment**: A `risk_assessment` outcome of HIGH on schedule
+  almost always means the input spec is missing corner-case requirements. Request spec clarification
+  before iterating on arch_exploration — additional exploration iterations will not resolve an
+  under-specified schedule risk.
+- **McPAT area estimates**: ±30% without technology calibration. Do not use raw McPAT numbers for
+  final area budgets; apply technology scaling factor from known tape-out data or designer input.
+- **gem5 OOO branch predictor**: Out-of-order gem5 models need branch predictor tuning to get within
+  15% of silicon IPC. Default LTAGE parameters are often mismatched for deeply embedded workloads —
+  tune `BTBEntries`, `RASSize`, and `numThreads` before reporting throughput numbers.
+
+## Successful Tool Flags
+
+- `gem5` in-order models (`MinorCPU`) are within 15% of silicon for in-order pipelines with no
+  branch-predictor tuning needed.
+- `mcpat --inorder` mode gives more accurate area estimates for in-order designs than the default
+  out-of-order configuration.
+- `cacti -cache_size <N> -block_size <B> -associativity <A>` — always specify all three to avoid
+  CACTI defaulting to parameters that do not match the design.
+
+## PDK / Tool Quirks
+
+- **Platform Architect**: requires licence server ping at startup; if `spec_analysis` hangs, check
+  `LM_LICENSE_FILE` and run `lmstat -a` before retrying.
+- **VSP (Cadence)**: TLM model import fails silently if the `.so` is compiled with a different GCC
+  ABI than the VSP runtime — rebuild with `--std=c++14` and matching `-fabi-version`.
+
+## Notes
+
+- McPAT and CACTI estimates should always be presented with explicit uncertainty bounds in the
+  microarchitecture document — do not round to "nice" numbers without noting the model error.

--- a/memory/compiler/knowledge.md
+++ b/memory/compiler/knowledge.md
@@ -1,0 +1,36 @@
+# Compiler Domain Knowledge
+
+## Known Failure Patterns
+
+- **LLVM backend register allocation errors**: Errors in `backend_dev` during register allocation
+  almost always indicate the wrong calling convention is specified. Verify `CallingConv::ID` in
+  `XXXCallingConv.td` matches the ABI spec before retrying codegen.
+- **Custom extensions without MC layer**: RISC-V custom extensions require the `MC` (Machine Code)
+  layer to be implemented before codegen can produce correct encodings. Attempting codegen without
+  MC causes silent encoding errors that surface only in ATPG or silicon validation.
+- **Miscompilation root cause**: Root cause is almost always instruction selection DAG patterns.
+  Use `llc -debug-only=isel` to dump the SelectionDAG before and after legalization. Compare
+  against the reference C output compiled with a known-good compiler (`riscv64-unknown-elf-gcc -O0`).
+
+## Successful Tool Flags
+
+- `clang -target riscv32-unknown-elf -march=rv32imXcustom` — use `-march` with custom extension
+  string to exercise new instruction patterns end-to-end from Clang through LLC.
+- `llc -verify-machineinstrs` — enables MachineInstr verification after each pass; catches
+  malformed instructions that would otherwise silently produce wrong code.
+- `llvm-mc --show-encoding` — verify binary encoding of each custom instruction before wiring
+  into codegen; catches TableGen pattern mismatches early.
+
+## PDK / Tool Quirks
+
+- **QEMU peripheral emulation gaps**: QEMU may not emulate custom CSRs or non-standard MMIO
+  peripherals. Runtime library tests that pass on QEMU but fail on silicon almost always involve
+  an unimplemented QEMU peripheral — validate against RTL simulation or FPGA prototype.
+- **GCC ABI for RISC-V custom extensions**: GCC requires a custom multilib configuration if the
+  extension changes the calling convention. Without it, mixing `-march` flags between objects causes
+  linker ABI conflicts.
+
+## Notes
+
+- Always run the full regression suite (`toolchain_validation`) with `-O0`, `-O1`, and `-O2`
+  separately — many miscompilations only appear at optimization levels > 0.

--- a/memory/dft/knowledge.md
+++ b/memory/dft/knowledge.md
@@ -1,0 +1,37 @@
+# DFT Domain Knowledge
+
+## Known Failure Patterns
+
+- **Scan DRC errors from clock gating cells**: The most common source of scan DRC errors is clock
+  gating cells without test control logic. Add test-enable (`TE`) ports to all ICG cells and verify
+  they connect to the scan enable network before running `scan_insertion`.
+- **ATPG coverage below 95%**: Coverage below 95% after full ATPG is almost always caused by
+  unpowered logic domains or missing tie-offs on unused inputs. Audit power domain boundaries and
+  ensure all unused inputs are tied high or low before retrying ATPG.
+- **BIST MISR false-pass**: MISR polynomial selection directly affects the probability of a
+  false-pass (aliasing). Use a primitive polynomial of degree equal to the MISR register width.
+  Default TetraMAX/Modus MISR polynomials are safe; custom implementations must be verified.
+
+## Successful Tool Flags
+
+- `tmax -scan_chain_length <N>` — setting explicit chain length prevents TetraMAX from creating
+  excessively long chains that degrade test application time.
+- `modus -coverage_model full_fault` — enables both SAF and TDF coverage tracking in a single run;
+  avoids a separate TDF run later in the flow.
+- `tessent -shell -dofile <script.do>` — batch mode avoids GUI overhead; use with structured dofiles
+  for repeatable flows.
+
+## PDK / Tool Quirks
+
+- **OpenROAD DFT**: `openroad -dft` scan insertion is functional for simple designs but does not
+  support hierarchical scan chain stitching across IP boundaries — use Yosys DFT plugin or
+  proprietary tools for SoC-level scan.
+- **Yosys `synth -flatten` interaction**: Flattening before scan insertion eliminates hierarchy
+  boundaries that block chain stitching, but significantly increases runtime on large designs.
+  Flatten selectively at the scan boundary level.
+
+## Notes
+
+- JTAG boundary scan connectivity (`jtag_setup`) should be validated with a BSDL file checker
+  before silicon — BSDL syntax errors cause test equipment to reject the device at incoming
+  inspection.

--- a/memory/firmware/knowledge.md
+++ b/memory/firmware/knowledge.md
@@ -1,0 +1,36 @@
+# Firmware Domain Knowledge
+
+## Known Failure Patterns
+
+- **QEMU peripheral emulation gaps**: QEMU peripheral emulation gaps cause false failures in
+  `bsp_development`. If a BSP test fails on QEMU but the register map looks correct, check whether
+  the peripheral is actually emulated — run `qemu-system-arm -machine help` and cross-reference
+  peripheral list. Use RTL simulation or FPGA bring-up to validate unimplemented peripherals.
+- **FreeRTOS stack overflow silent corruption**: Stack overflows without `configCHECK_FOR_STACK_OVERFLOW=2`
+  corrupt adjacent task stacks silently, producing non-deterministic crashes. Always build FreeRTOS
+  with `configCHECK_FOR_STACK_OVERFLOW=2` and `configUSE_MALLOC_FAILED_HOOK=1` during development.
+- **Bare-metal clock tree validation**: Peripheral init before clock tree validation causes
+  intermittent failures that are extremely difficult to root-cause. Always validate PLL lock and
+  clock dividers before initialising any peripheral in `bsp_development`.
+
+## Successful Tool Flags
+
+- `arm-none-eabi-gcc -fstack-usage` — generates `.su` files with per-function stack usage;
+  use to calculate worst-case stack depth before setting FreeRTOS task stack sizes.
+- `openocd -f interface/<probe>.cfg -f target/<mcu>.cfg -c "program <elf> verify reset exit"` —
+  combined flash-program-and-verify command; the `verify` step catches flash write failures
+  that corrupt the image silently.
+- `riscv64-unknown-elf-objdump -d --visualize-jumps` — useful for spotting unexpected branches
+  in startup code during bring-up.
+
+## PDK / Tool Quirks
+
+- **J-Link RTT buffer sizing**: Increase `SEGGER_RTT_BUFFER_SIZE_UP` to at least 4096 for bring-up
+  logging; the default 1024 bytes causes log drops at high baud rates.
+- **TRACE32 JTAG speed**: Lower JTAG clock to ≤ 1 MHz during early bring-up until power delivery
+  is validated; marginal power rails cause JTAG corruption at higher speeds.
+
+## Notes
+
+- `stress_test_24h_clean` is the sign-off gate — run it on target hardware, not QEMU.
+  A QEMU 24h pass does not substitute for hardware validation.

--- a/memory/formal/knowledge.md
+++ b/memory/formal/knowledge.md
@@ -1,0 +1,36 @@
+# Formal Verification Domain Knowledge
+
+## Known Failure Patterns
+
+- **Vacuous proofs from over-constrained environment**: A vacuous proof means the `assume`
+  constraints in `environment_setup` make the input space unreachable. Run vacuity check
+  (`sby --vacuity`) after every environment iteration. If vacuity is detected, relax constraints
+  one at a time — do not remove all constraints and re-add, as this loses context.
+- **Insufficient bound depth**: SymbiYosys `--depth` must be set to at least `pipeline_depth + 2`
+  to exercise all pipeline stages. Shallow bounds produce false "PASS" results for properties that
+  only fire at the end of a pipeline.
+- **LEC failures after synthesis**: LEC unmatched points after synthesis almost always indicate
+  clock-gating cells that need equivalence mapping (`set_dont_touch` or explicit mapping script).
+  Provide the synthesis tool's clock-gating cell list to the LEC tool before running.
+
+## Successful Tool Flags
+
+- `sby -f <task>.sby --depth <N>` — always set `--depth` explicitly; never rely on default bound.
+- `sby --multiclock` — required when the design has multiple clock domains; single-clock mode
+  silently ignores cross-domain paths.
+- `jg -allow_empty_cex` — prevents JasperGold from treating an empty CEX set as proof of vacuity;
+  use with explicit vacuity check script.
+
+## PDK / Tool Quirks
+
+- **Z3 vs Boolector for bitvector arithmetic**: Z3 is generally faster for designs with heavy
+  arithmetic; Boolector outperforms Z3 on pure Boolean problems. Try both when a proof runs
+  for > 30 minutes without result.
+- **Yosys `prep` before sby**: Running `yosys -p "prep -top <top>"` on the design before
+  invoking SymbiYosys catches synthesis elaboration errors early and significantly reduces
+  proof setup time.
+
+## Notes
+
+- CEX found for a P0 property = hard blocker. Suspend the formal flow, report to the RTL
+  team with the full counterexample trace, and do not retry until RTL fix is confirmed.

--- a/memory/fpga/knowledge.md
+++ b/memory/fpga/knowledge.md
@@ -1,0 +1,40 @@
+# FPGA Domain Knowledge
+
+## Known Failure Patterns
+
+- **BRAM inference coding style**: Xilinx BRAM inference requires a specific coding style — the
+  read data output must be registered (synchronous read), and the reset must not be applied to
+  the output register. Designs with asynchronous BRAM reads infer LUT RAM instead, consuming
+  significantly more LUTs.
+- **DSP48 inference blocked by carry-chains**: Arithmetic trees that mix additions and subtractions
+  with intermediate carry-chains prevent DSP48 inference. Restructure to keep the full
+  multiply-accumulate within a single DSP48 primitive; use `(* use_dsp = "yes" *)` attribute
+  to force inference.
+- **Prototype frequency target**: Set the FPGA prototype frequency target to 1/3 of the ASIC
+  target to account for FPGA fabric overhead. For example, a 1 GHz ASIC target maps to ~333 MHz
+  FPGA prototype target. Document the scale factor explicitly in the sign-off report.
+
+## Successful Tool Flags
+
+- `vivado -mode batch -source <script.tcl>` — batch mode for reproducible synthesis/P&R; use
+  `set_property STEPS.SYNTH_DESIGN.ARGS.FLATTEN_HIERARCHY none [get_runs synth_1]` to preserve
+  hierarchy for debug.
+- `nextpnr-xilinx --freq <MHz>` — always set target frequency explicitly; unconstrained nextpnr
+  runs do not optimize for timing.
+- `openFPGALoader --cable <cable> --verify` — `--verify` reads back bitstream after programming
+  to catch flash write failures.
+
+## PDK / Tool Quirks
+
+- **Vivado IP core out-of-context synthesis**: OOC synthesis must complete before top-level
+  synthesis or Vivado silently uses stale netlists. Run `synth_ip [get_ips *]` before top-level
+  `launch_runs synth_1`.
+- **nextpnr-xilinx chip database**: Requires a device-specific chip database built from
+  Project X-Ray. Ensure the database matches the exact device part number — mismatches cause
+  routing failures that appear as DRC errors.
+
+## Notes
+
+- All performance measurements on the FPGA prototype must be recorded at prototype frequency
+  with the ASIC scale factor noted. Reporting FPGA MHz directly as a performance number
+  without the scale factor is misleading.

--- a/memory/hls/knowledge.md
+++ b/memory/hls/knowledge.md
@@ -1,0 +1,37 @@
+# HLS Domain Knowledge
+
+## Known Failure Patterns
+
+- **PIPELINE II=1 failure on memory-bound loops**: Vitis HLS `PIPELINE II=1` on memory-bound
+  loops almost always fails because array accesses create resource conflicts. Resolve by partitioning
+  arrays (`#pragma HLS ARRAY_PARTITION variable=<arr> cyclic factor=<N>`) or using `PIPELINE II=2`
+  as an interim target while restructuring access patterns.
+- **DATAFLOW pragma requires producer/consumer channels**: `#pragma HLS DATAFLOW` requires every
+  producer-consumer pair to communicate via a stream or ping-pong buffer. Bypassing this (e.g.,
+  using a regular array between DATAFLOW tasks) causes HLS to ignore the pragma silently with no
+  error — verify with the dataflow viewer.
+- **Latency target misses**: Latency target misses are almost always resolved by loop unrolling
+  (`#pragma HLS UNROLL factor=<N>`) or partitioning arrays — not by increasing clock frequency.
+  Try array partitioning first as it has lower area overhead than full unroll.
+
+## Successful Tool Flags
+
+- `vitis_hls -f <script.tcl>` with `config_compile -pipeline_loops 0` — disables automatic
+  loop pipelining; use when manual `PIPELINE` directives are preferred over automatic insertion.
+- `bambu --target-file=<xml> --top-fname=<func> --simulate` — always use `--simulate` to catch
+  output mismatches at the HLS level before RTL QC.
+- `circt-opt --lower-calyx-to-fsm` — useful for inspecting generated FSM structure from Calyx IR.
+
+## PDK / Tool Quirks
+
+- **Catapult reset inference**: Catapult infers resets from variable initialization in C++.
+  Uninitialized variables that happen to read as zero in simulation may not have reset logic in
+  RTL — explicitly initialize all variables used in reset-dependent logic.
+- **Bambu vs Vitis for floating point**: Bambu generates IEEE-754 compliant FP units natively;
+  Vitis HLS FP operations use Xilinx FP IP cores which are non-IEEE on NaN/infinity handling.
+  Use Bambu for portability if FP edge cases matter.
+
+## Notes
+
+- Co-simulation output mismatch is always a blocker. Root cause before retry — do not assume
+  the mismatch is a simulation artifact.

--- a/memory/pd/knowledge.md
+++ b/memory/pd/knowledge.md
@@ -1,0 +1,40 @@
+# Physical Design Domain Knowledge
+
+## Known Failure Patterns
+
+- **ORFS density > 65% → routing congestion**: OpenROAD/ORFS placement density above 65% almost
+  always correlates with routing congestion (DRC violations in routing stage). Reduce target
+  density in `floorplan` to 60–65% before retrying; do not push past 70% without manual congestion
+  analysis.
+- **CTS target skew for sky130 at 500 MHz**: Use 50 ps target skew for 500 MHz designs in sky130.
+  Tighter targets (< 30 ps) are unreachable with OpenROAD CTS and will cause the CTS stage to
+  loop indefinitely.
+- **Post-route timing closure ECO rounds**: Post-route timing closure typically requires 2–3 ECO
+  rounds. If WNS has not converged after 3 rounds, escalate to floorplan revision — incremental
+  ECO will not close timing if the root cause is placement congestion.
+- **LVS failures from missing substrate tie-offs**: The most common LVS failure in sky130 is
+  missing n-well tie-offs and substrate tie-offs for standard cells. Ensure the PDK standard
+  cell library includes tie-off cells and that the floorplan inserts them at the required pitch.
+
+## Successful Tool Flags
+
+- `make DESIGN_CONFIG=... finish` (ORFS) — run the full pipeline to completion before reading
+  `reports/.../metrics.json`; partial runs leave stale metrics files.
+- `klayout -rd input=<gds> -r <drc_script.rb> -zz` — batch DRC mode; `-zz` suppresses GUI and
+  is required for CI/CD integration.
+- `openroad -no_init` with `read_lef`/`read_def`/`report_checks` TCL sequence — useful for
+  one-shot timing queries on a routed design without reloading the full ORFS database.
+
+## PDK / Tool Quirks
+
+- **sky130 antenna rules**: sky130 antenna rules are stricter than most commercial PDKs. Enable
+  antenna repair (`repair_antennas`) in OpenROAD after routing; expect 5–15% of nets to need
+  repair on a typical design.
+- **OpenROAD global routing vs detailed routing DRC**: Global routing DRC (overflow) does not
+  guarantee detailed routing DRC clean. Always run `detailed_route` and check `drc_count` from
+  the metrics file — not the global routing overflow count.
+
+## Notes
+
+- `core_area_util_pct` above 85% at sign-off is a hard stop — route congestion and ECO closure
+  become intractable above this threshold in sky130 with OpenROAD.

--- a/memory/rtl-design/knowledge.md
+++ b/memory/rtl-design/knowledge.md
@@ -1,0 +1,38 @@
+# RTL Design Domain Knowledge
+
+## Known Failure Patterns
+
+- **Verilator -Wall catches implicit wire declarations**: Verilator with `-Wall` catches implicit
+  wire declarations that SpyGlass and Synopsys DC may silently accept. Always run Verilator lint
+  first — it surfaces issues that prevent correct synthesis even when proprietary tools do not error.
+- **CDC violations from multi-bit signals**: Multi-bit signals crossing clock domains require both
+  a synchronizer AND Gray encoding. A 2-FF synchronizer alone is insufficient for multi-bit vectors;
+  the intermediate states cause functional errors that are intermittent and hard to reproduce in
+  simulation.
+- **Async reset flops need reset-removal SDC constraints**: Asynchronous reset flops require
+  explicit reset-removal timing constraints in the SDC (`set_max_delay -datapath_only` from reset
+  deassertion to first flop clock edge). Without these, STA will either flag false violations or
+  miss real metastability windows.
+
+## Successful Tool Flags
+
+- `verilator --lint-only -Wall -Wno-DECLFILENAME <files>` — `-Wno-DECLFILENAME` suppresses the
+  common false positive where file name doesn't match module name; keep all other `-Wall` checks.
+- `slang --allow-use-before-declare --strict-driver-checking <files>` — `--strict-driver-checking`
+  catches multi-driven signals that Verilator misses.
+- `sv2v --top <module> <files> > out.v && iverilog -Wall out.v` — useful for catching
+  SystemVerilog elaboration issues in tools that don't support SV directly.
+
+## PDK / Tool Quirks
+
+- **SpyGlass CDC vs JasperGold CDC**: SpyGlass CDC reports more false positives on Gray-encoded
+  buses; JasperGold CDC gives fewer false positives but misses some structural CDC patterns.
+  Use SpyGlass first to get full coverage, then waive false positives with documented rationale.
+- **Yosys synth_check with sky130**: `yosys -p "synth -top <top>; check"` on sky130 designs
+  requires Surelog for SystemVerilog elaboration — native Yosys SV support is incomplete for
+  complex parameter overrides.
+
+## Notes
+
+- RTL sign-off package must include `filelist.f` with relative paths. Absolute paths in filelist
+  break downstream synthesis flows that run from a different working directory.

--- a/memory/soc/knowledge.md
+++ b/memory/soc/knowledge.md
@@ -1,0 +1,39 @@
+# SoC Integration Domain Knowledge
+
+## Known Failure Patterns
+
+- **AXI4 memory map conflicts → chip_level_sim failure**: AXI4 memory map conflicts are the #1
+  cause of `chip_level_sim` failures. Before `top_integration`, generate a full memory map from
+  all IP block configurations and verify no address ranges overlap. FuseSoC address map exports
+  can be validated with `fusesoc gen --target sim <core>` before integration.
+- **FuseSoC IP version pinning**: FuseSoC core dependency resolution fails silently when IP
+  versions are unpinned and the registry has newer incompatible versions. Always pin IP versions
+  in `<design>.core` using `=` (exact) version constraints, not `^` (compatible) — compatible
+  constraints have caused breakage when upstream IPs changed interfaces.
+- **Bus fabric address decoder verification**: Address decoder errors in `bus_fabric_setup` are
+  not caught by RTL lint. Validate the decoder with a directed simulation test that walks all
+  address boundaries (base, base+1, top-1, top) before `top_integration`.
+
+## Successful Tool Flags
+
+- `fusesoc --cores-root <path> run --target sim <core>` — `--cores-root` overrides the default
+  registry; use to point at local IP copies during integration before publishing to registry.
+- `verilator --sc --exe --build -Wno-UNOPTFLAT <files>` — `--sc` enables SystemC output needed
+  for cocotb/TLM integration; `-Wno-UNOPTFLAT` suppresses expected warnings from AXI bus
+  combinational loops.
+- `edalize build --tool <tool>` — Edalize abstracts tool-specific project file generation;
+  prefer over hand-written Makefiles for simulator portability.
+
+## PDK / Tool Quirks
+
+- **Verilator AXI4 burst simulation**: Verilator does not model AXI4 burst interleaving by
+  default — cocotb or a VIP is required for protocol-level bus verification. Verilator alone
+  is sufficient only for functional correctness, not protocol compliance.
+- **FuseSoC .core file VLNV**: VLNV (Vendor:Library:Name:Version) must be unique across all
+  cores in the registry. Duplicate VLNVs cause FuseSoC to silently use the first match found,
+  which may be the wrong version.
+
+## Notes
+
+- `unqualified_ips: 0` is a hard sign-off gate. Never proceed to synthesis with unqualified IP —
+  IP qualification failures discovered post-synthesis require full re-integration.

--- a/memory/sta/knowledge.md
+++ b/memory/sta/knowledge.md
@@ -1,0 +1,42 @@
+# STA Domain Knowledge
+
+## Known Failure Patterns
+
+- **OpenSTA hold analysis without set_propagated_clock**: OpenSTA `set_propagated_clock` is
+  required before hold analysis. Without it, OpenSTA uses ideal clock (zero skew) for hold
+  checks, which produces false "clean hold" results that fail on silicon. Always call
+  `set_propagated_clock [all_clocks]` in the STA script before `report_checks -path_delay min`.
+- **Multi-corner hold closure needs target library hold_margin**: Multi-corner hold closure in
+  sky130 usually requires setting a `hold_margin` in the target liberty file. The default
+  hold_margin of 0 ps is insufficient for signoff at slow-slow corner with RCMAX parasitics —
+  add 50–100 ps margin.
+- **ECO cells > 2% → upstream issue**: If ECO cell count exceeds 2% of total cells during
+  `eco_guidance`, this almost always indicates a floorplan or CTS issue upstream — not a timing
+  exception problem. Escalate to the physical design team rather than continuing ECO iteration.
+- **rcx extraction accuracy for hold at 28nm and below**: RCX extraction accuracy significantly
+  affects hold timing at 28nm and below. OpenROAD's built-in RC estimator (`estimate_parasitics`)
+  is not accurate enough for hold signoff — use SPEF from a dedicated extraction tool (Calibre xRC,
+  StarRC, or OpenRCX with calibrated rules).
+
+## Successful Tool Flags
+
+- `sta -exit <script.tcl>` — `-exit` ensures OpenSTA exits cleanly with a return code; required
+  for CI/CD integration where a hung process would block the pipeline.
+- `report_timing -path_type full_clock_expanded -delay_type max -nworst 10` — `full_clock_expanded`
+  shows full clock network paths; essential for diagnosing clock skew contributions to WNS.
+- `report_slack_histogram -num_bins 20` — quick overview of slack distribution; use before
+  detailed path analysis to understand whether violations are widespread or concentrated.
+
+## PDK / Tool Quirks
+
+- **PrimeTime POCV vs AOCV**: PrimeTime POCV (parametric OCV) is more accurate than AOCV for
+  advanced nodes but requires POCV coefficient files from the PDK vendor. Using AOCV on a design
+  that has POCV coefficients available leaves pessimism on the table.
+- **Tempus multi-mode multi-corner**: Tempus MMMC setup requires a `constraint_mode` and
+  `delay_corner` for every combination — missing combinations produce incorrect "all clear" reports
+  for unconstrained paths.
+
+## Notes
+
+- STA signoff requires `setup_wns_ns >= 0` AND `setup_tns_ps == 0` AND `hold_wns_ps >= 0`
+  AND `hold_tns_ps == 0` at ALL corners. A single failing corner blocks tape-out.

--- a/memory/synthesis/knowledge.md
+++ b/memory/synthesis/knowledge.md
@@ -1,0 +1,42 @@
+# Synthesis Domain Knowledge
+
+## Known Failure Patterns
+
+- **Yosys -flatten required for hierarchical sky130 designs**: Yosys synthesis of hierarchical
+  designs targeting sky130 PDK requires `-flatten` in the `synth` pass. Without flattening,
+  technology mapping fails to optimize across hierarchy boundaries, producing ~15–20% area
+  overhead vs. flattened synthesis. Use `synth -top <top> -flatten` for sky130 targets.
+- **Genus set_max_area alone does not close WNS**: In Cadence Genus, `set_max_area 0` alone
+  does not drive timing closure. WNS violations persist if timing constraints are not applied
+  before area optimization. Always set timing constraints (`create_clock`, `set_input_delay`,
+  `set_output_delay`) before `compile_ultra` — area optimization runs automatically within the
+  timing budget.
+- **Scan chain false paths before compile_ultra**: Scan chain false paths must be declared in the
+  SDC (`set_false_path -from [get_ports scan_in] -to [get_ports scan_out]`) before `compile_ultra`.
+  Declaring them after causes Fusion Compiler to re-optimize scan paths, breaking chain continuity
+  and requiring LEC re-run.
+
+## Successful Tool Flags
+
+- `yosys -p "synth -top <top> -flatten; dfflibmap -liberty <lib.lib>; abc -liberty <lib.lib> -D <period_ps>"` —
+  complete Yosys synthesis command for sky130; `-D <period_ps>` sets the timing target for ABC
+  delay optimization.
+- `dc_shell -f <script.tcl> -output_log_file <log>` — always capture the log; `check_design`
+  warnings about unresolved references are the most common root cause of synthesis failures.
+- `genus -legacy_ui -files <script.tcl>` — `--legacy_ui` mode is more stable for scripted flows
+  than the default UI mode; avoids interactive prompts that hang batch jobs.
+
+## PDK / Tool Quirks
+
+- **`ultra` effort past 2× loop-backs**: `compile_ultra` with `ultra` effort rarely closes WNS
+  past 2 loop-back iterations — further effort yields < 1% improvement at 3–5× runtime cost.
+  Switch to targeted path optimization (`compile_ultra -only_design_rule` + `optimize_registers`)
+  after 2 failed `compile_ultra` runs.
+- **ABC liberty compatibility**: ABC requires liberty files without `pg_pin` (power/ground pin)
+  entries. Strip `pg_pin` blocks from sky130 liberty with `sed '/pg_pin/,/^  }/d'` before passing
+  to Yosys/ABC — `pg_pin` entries cause ABC to silently ignore the cell.
+
+## Notes
+
+- LEC must be run after every netlist change — not just at signoff. A single unverified netlist
+  change that reaches PD and fails LEC there costs a full PD re-run.

--- a/memory/verification/knowledge.md
+++ b/memory/verification/knowledge.md
@@ -1,0 +1,42 @@
+# Verification Domain Knowledge
+
+## Known Failure Patterns
+
+- **UVM factory override failures → uvm_tb_build failures**: UVM factory override issues are the
+  #1 cause of `uvm_tb_build` failures. Symptoms: `uvm_fatal` with "object of type X expected but
+  Y received" at simulation start. Root cause: override registered after `run_test()` call, or
+  type name string mismatch (case-sensitive). Always register overrides in `build_phase`, before
+  `super.build_phase()`.
+- **Functional coverage closure stalls at constrained_random**: Stalls in functional coverage
+  closure are often caused by unreachable corner cases that random stimulus cannot hit. Before
+  adding more constrained random sequences, analyze the uncovered bins — if they require specific
+  ordering of >3 events, write a directed test targeting exactly that sequence.
+- **Assertion-based coverage complement**: Assertion-based coverage (via `$rose`, `$fell`, SVA
+  covers) complements functional coverage by catching protocol violations that would otherwise
+  only appear as silent data corruption. Wire SVA cover points to the coverage database to avoid
+  double-counting them as functional coverage.
+
+## Successful Tool Flags
+
+- `verilator --coverage --coverage-line --coverage-toggle -Wno-UNOPTFLAT` — enables line,
+  toggle, and user coverage collection; `-Wno-UNOPTFLAT` suppresses expected warnings from
+  UVM dynamic connections.
+- `vcs -sverilog +vcs+lic+wait +UVM_NO_RELNOTES -cm line+cond+fsm+tgl` — `+vcs+lic+wait`
+  prevents licence timeout failures in batch regressions; `-cm` flags enable all coverage types.
+- `xrun -uvm -coverage all -covworkdir <dir>` — Xcelium coverage merge from multiple regression
+  runs; `-covworkdir` must be consistent across all runs for merge to succeed.
+
+## PDK / Tool Quirks
+
+- **Verilator UVM library**: The open-source UVM library (`uvm-core`) compiles with Verilator
+  but does not support all UVM phasing features. Specifically, `uvm_objection` timeout-based
+  drain time is not supported — use explicit event-based drain instead.
+- **cocotb + Verilator coverage**: cocotb does not natively export Verilator coverage to the
+  standard UCDB format. Use `verilator_coverage --write-info <info> <dat>` to convert, then
+  `urg -dir <info>` for HTML reports.
+
+## Notes
+
+- `open_p0_bugs: 0` is a hard sign-off gate. Do not proceed to `regression_signoff` with any
+  P0 or P1 bugs open — re-opening a regression signoff after a deferred P0 fix costs a full
+  regression re-run.

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -85,3 +85,37 @@ Each stage must return:
 2. Enforce loop-back rules strictly — do not proceed past a FAIL
 3. If max iterations exceeded: stop, present full state and escalation report
 4. On completion: produce microarchitecture document and RTL handoff package
+5. Read `memory/architecture/knowledge.md` before the first stage and write an experience record to `memory/architecture/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `spec_analysis`, read `memory/architecture/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/architecture/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "architecture",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "selected_arch": "<value>",
+    "estimated_mhz": "<value>",
+    "estimated_area_um2": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -46,3 +46,37 @@ isa_analysis → backend_dev → assembler_dev → linker_config → runtime_lib
 2. Miscompilation (wrong output) = P0 blocker — root cause required before retry
 3. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
 4. Output: toolchain release package + validation report + ABI spec
+5. Read `memory/compiler/knowledge.md` before the first stage and write an experience record to `memory/compiler/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `isa_analysis`, read `memory/compiler/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/compiler/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "compiler",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "isa_tests_passed": "<value>",
+    "abi_compliant": "<value>",
+    "regression_pass_rate": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -50,3 +50,36 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track fault_coverage in state across all ATPG iterations
 3. Do not proceed to dft_signoff until SAF coverage meets target
 4. Output: DFT netlist, .scandef, ATPG patterns, BSDL file
+5. Read `memory/dft/knowledge.md` before the first stage and write an experience record to `memory/dft/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `dft_architecture`, read `memory/dft/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/dft/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "dft",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "scan_coverage_pct": "<value>",
+    "atpg_fault_coverage_pct": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -46,3 +46,37 @@ bsp_development → peripheral_drivers → rtos_integration → driver_validatio
 2. Do not proceed to rtos_integration until ALL drivers pass unit tests
 3. Track drivers_complete[] in state — partial driver list blocks RTOS stage
 4. Output: validated firmware package + bring-up guide + known issues list
+5. Read `memory/firmware/knowledge.md` before the first stage and write an experience record to `memory/firmware/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `bsp_development`, read `memory/firmware/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/firmware/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "firmware",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "build_pass": "<value>",
+    "flash_size_kb": "<value>",
+    "bsp_tests_passed": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -53,3 +53,37 @@ When invoking open-source tools, follow the execution hierarchy:
 2. CEX from RTL bug: suspend, report to RTL team, wait for fix confirmation before retry
 3. Flag any unproven P0 property as a hard blocker for sign-off
 4. Vacuity check required after every environment_setup iteration
+5. Read `memory/formal/knowledge.md` before the first stage and write an experience record to `memory/formal/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `property_planning`, read `memory/formal/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/formal/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "formal",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "proved": "<value>",
+    "failed": "<value>",
+    "unknown": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -57,3 +57,37 @@ When invoking open-source tools, follow the execution hierarchy:
 3. SW bugs: fix in firmware without re-synthesising unless HW root cause confirmed
 4. All performance measurements: record at prototype frequency with scale factor noted
 5. Output: prototype sign-off report + HW bug report for RTL team + performance baseline
+6. Read `memory/fpga/knowledge.md` before the first stage and write an experience record to `memory/fpga/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `rtl_adaptation`, read `memory/fpga/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/fpga/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "fpga",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "lut_count": "<value>",
+    "fmax_mhz": "<value>",
+    "timing_met": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -54,3 +54,37 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track hls_report metrics (latency, II, area) in state across iterations
 3. Co-simulation output mismatch is always a blocker — root cause before retry
 4. Output: HLS RTL package + co-sim report + interface documentation
+5. Read `memory/hls/knowledge.md` before the first stage and write an experience record to `memory/hls/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `algorithm_analysis`, read `memory/hls/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/hls/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "hls",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "latency_cycles": "<value>",
+    "dsp_count": "<value>",
+    "ii_achieved": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -65,3 +65,38 @@ placed/routed, prefer:
 2. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
 3. Never proceed past a FAIL without applying the loop-back rule
 4. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report
+5. Read `memory/pd/knowledge.md` before the first stage and write an experience record to `memory/pd/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `floorplan`, read `memory/pd/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/pd/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "pd",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "wns_ns": "<value>",
+    "drc_violations": "<value>",
+    "lvs_errors": "<value>",
+    "gds_area_um2": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -55,3 +55,37 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Enforce SystemVerilog coding standards from skill at every rtl_coding stage
 3. Escalate clearly if max iterations exceeded — show state and root cause
 4. Output: RTL package (filelist.f, all .sv files, assertions, lint/CDC reports)
+5. Read `memory/rtl-design/knowledge.md` before the first stage and write an experience record to `memory/rtl-design/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `module_planning`, read `memory/rtl-design/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/rtl-design/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "rtl-design",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "lint_errors": "<value>",
+    "cdc_violations": "<value>",
+    "synth_check_pass": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -53,3 +53,37 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Block progression if any IP has unresolved qualification issues
 3. Track ip_status{} per IP in state — never proceed with unqualified IP
 4. Output: integrated SoC RTL package ready for synthesis
+5. Read `memory/soc/knowledge.md` before the first stage and write an experience record to `memory/soc/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `ip_procurement`, read `memory/soc/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/soc/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "soc",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "ip_blocks_integrated": "<value>",
+    "simulation_pass": "<value>",
+    "memory_map_conflicts": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -60,3 +60,38 @@ highest-value MCP use case in the entire flow.
 3. LEC required after every ECO batch — do not accumulate ECOs without equivalence check
 4. ECO count > 2% of cells: hard stop, escalate to physical design team
 5. Do not enter eco_guidance if any exception in exception_review is pending sign-off — block until resolved
+6. Read `memory/sta/knowledge.md` before the first stage and write an experience record to `memory/sta/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `constraint_validation`, read `memory/sta/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/sta/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "sta",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "setup_wns_ns": "<value>",
+    "hold_wns_ns": "<value>",
+    "tns_ns": "<value>",
+    "failing_paths": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -50,3 +50,38 @@ When invoking open-source tools, follow the execution hierarchy:
 1. Read logic-synthesis skill before each stage
 2. On completion: produce PD handoff package (netlist, SDC, timing/area/power reports)
 3. LEC must be run after every netlist change — not just at sign-off
+4. Read `memory/synthesis/knowledge.md` before the first stage and write an experience record to `memory/synthesis/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `constraint_setup`, read `memory/synthesis/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/synthesis/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "synthesis",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "wns_ns": "<value>",
+    "cells": "<value>",
+    "area_um2": "<value>",
+    "lec_unmatched": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -54,3 +54,37 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track all bugs in state bugs_found[] — do not discard between stages
 3. Do not proceed to regression_signoff if any P0/P1 bugs remain open
 4. Bug found during directed tests: suspend flow; present RTL fix required report
+5. Read `memory/verification/knowledge.md` before the first stage and write an experience record to `memory/verification/experiences.jsonl` after signoff or escalation.
+
+## Memory
+
+### Read (session start)
+Before beginning `tb_architecture`, read `memory/verification/knowledge.md` if it exists.
+Incorporate its guidance into stage decisions — especially known failure patterns,
+successful tool flags, and PDK-specific notes. If the file does not exist, proceed
+without it.
+
+### Write (session end)
+After signoff (or on escalation/abandon), append one JSON line to
+`memory/verification/experiences.jsonl`:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "domain": "verification",
+  "design_name": "<from state>",
+  "pdk": "<from state if known, else null>",
+  "tool_used": "<primary tool>",
+  "stages_completed": ["<stage>", "..."],
+  "loop_backs": {"<stage>": "<count>", "..."},
+  "key_metrics": {
+    "functional_coverage_pct": "<value>",
+    "regression_failures": "<value>",
+    "assertions_triggered": "<value>"
+  },
+  "issues_encountered": ["<description>", "..."],
+  "fixes_applied": ["<description>", "..."],
+  "signoff_achieved": true,
+  "notes": "<free-text observations>"
+}
+```
+Create the file and parent directories if they do not exist.


### PR DESCRIPTION
## Summary

- Adds a two-tier file-based memory system (`memory/`) so orchestrators accumulate knowledge across sessions without any new infrastructure
- **Tier 1** — `memory/<domain>/experiences.jsonl`: append-only JSONL written by orchestrators at session end (one record per run)
- **Tier 2** — `memory/<domain>/knowledge.md`: human+agent-readable distilled knowledge, seeded with domain-specific failure patterns, tool flags, and PDK quirks
- All 13 domain orchestrators (architecture, compiler, dft, firmware, formal, fpga, hls, pd, rtl-design, soc, sta, synthesis, verification) updated with a `## Memory` section and a new Behaviour Rule
- `FUTURE_WORK.md` captures four deferred items: memory-keeper skill, semantic search over experiences, cross-design metric trending, and infrastructure orchestrator memory

## What changed

| Area | Files |
|------|-------|
| New `memory/` directory | `README.md`, `designs/.gitkeep`, 13 × `knowledge.md` |
| New repo-root file | `FUTURE_WORK.md` |
| Modified orchestrators | All 13 domain orchestrator `.md` files |

## How it works

**Session start**: orchestrator reads `memory/<domain>/knowledge.md` before its first stage and incorporates guidance into decisions (known failure patterns, successful flags, PDK quirks).

**Session end**: orchestrator appends one JSONL record to `memory/<domain>/experiences.jsonl` with timestamps, stages completed, loop-back counts, domain-specific QoR metrics, issues encountered, fixes applied, and free-text notes.

## Test plan

- [x] `memory/` tree exists with all 13 `knowledge.md` files and `README.md`
- [x] Each orchestrator `.md` has exactly one `## Memory` section with correct domain path and first-stage name
- [x] JSONL schema in `memory/README.md` matches the per-domain `key_metrics` table
- [x] Behaviour rule N is correctly numbered (no gaps, no duplicates)
- [ ] Manual runtime test: run synthesis orchestrator on a small design; confirm `memory/synthesis/experiences.jsonl` is created with a valid JSON line and orchestrator output references reading `knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)