### PR TITLE
[Fix] Fix agent memory update loophole

### DIFF
--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -85,7 +85,7 @@ Each stage must return:
 2. Enforce loop-back rules strictly — do not proceed past a FAIL
 3. If max iterations exceeded: stop, present full state and escalation report
 4. On completion: produce microarchitecture document and RTL handoff package
-5. Read `memory/architecture/knowledge.md` before the first stage and write an experience record to `memory/architecture/experiences.jsonl` after signoff or escalation.
+5. Read `memory/architecture/knowledge.md` before the first stage. Write an experience record to `memory/architecture/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -118,4 +118,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -50,7 +50,7 @@ When invoking open-source tools, follow the execution hierarchy:
 Initialise and maintain this JSON state across all stages:
 ```json
 {
-  "run_id": "architecture_<YYYYMMDD>_<HHMMSS>",
+  "run_id": "architecture_<YYYYMMDD>_<HHMMSSmmm>_<shortUUID>",
   "design_name": "<from user>",
   "stages": {
     "spec_analysis": { "status": "pending", "output": {} },
@@ -96,8 +96,12 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
-`memory/architecture/experiences.jsonl`:
+On any termination path (signoff, escalation, abandonment, interruption, error, or max-turns
+reached), upsert one JSON record in `memory/architecture/experiences.jsonl`. Implement the
+upsert by reading the file as newline-delimited JSON objects, filtering out any existing line
+where `run_id` matches the incoming value, appending the new record as a single JSON line, and
+atomically replacing the file (write to a temp file, then rename) to avoid partial writes. Each
+line must be a valid JSON object followed by a newline:
 ```json
 {
   "run_id": "<from state>",
@@ -119,5 +123,5 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
   "notes": "<free-text observations>"
 }
 ```
-If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
-Create the file and parent directories if they do not exist.
+Set `signoff_achieved: false` on partial runs (interrupted, error, max-turns); set to `true` only
+on successful signoff. Create the file and parent directories if they do not exist.

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -50,7 +50,7 @@ When invoking open-source tools, follow the execution hierarchy:
 Initialise and maintain this JSON state across all stages:
 ```json
 {
-  "run_id": "arch_001",
+  "run_id": "architecture_<YYYYMMDD>_<HHMMSS>",
   "design_name": "<from user>",
   "stages": {
     "spec_analysis": { "status": "pending", "output": {} },
@@ -96,10 +96,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/architecture/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "architecture",
   "design_name": "<from state>",

--- a/plugins/architecture/skills/architecture/SKILL.md
+++ b/plugins/architecture/skills/architecture/SKILL.md
@@ -201,3 +201,16 @@ PPA modelling, risk assessment, and sign-off.
 - Final trade-off decision record
 - RTL design guidelines
 - Hand-off package
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/architecture/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `architecture_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -57,10 +57,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/compiler/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "compiler",
   "design_name": "<from state>",

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -46,7 +46,7 @@ isa_analysis → backend_dev → assembler_dev → linker_config → runtime_lib
 2. Miscompilation (wrong output) = P0 blocker — root cause required before retry
 3. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
 4. Output: toolchain release package + validation report + ABI spec
-5. Read `memory/compiler/knowledge.md` before the first stage and write an experience record to `memory/compiler/experiences.jsonl` after signoff or escalation.
+5. Read `memory/compiler/knowledge.md` before the first stage. Write an experience record to `memory/compiler/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -79,4 +79,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/compiler/skills/compiler-toolchain/SKILL.md
+++ b/plugins/compiler/skills/compiler-toolchain/SKILL.md
@@ -249,3 +249,16 @@ SECTIONS {
 - Validation report
 - ABI specification (final)
 - Known issues list
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/compiler/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `compiler_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/compiler/skills/compiler-toolchain/SKILL.md
+++ b/plugins/compiler/skills/compiler-toolchain/SKILL.md
@@ -261,4 +261,6 @@ write or overwrite one JSON record in `memory/compiler/experiences.jsonl` keyed 
 without full orchestrator context.
 
 Use `run_id` = `compiler_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+stage update). Every JSON record written must include a top-level `"run_id"` field
+whose value matches this key — this is what makes overwrites unambiguous. Set
+`signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -50,7 +50,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track fault_coverage in state across all ATPG iterations
 3. Do not proceed to dft_signoff until SAF coverage meets target
 4. Output: DFT netlist, .scandef, ATPG patterns, BSDL file
-5. Read `memory/dft/knowledge.md` before the first stage and write an experience record to `memory/dft/experiences.jsonl` after signoff or escalation.
+5. Read `memory/dft/knowledge.md` before the first stage. Write an experience record to `memory/dft/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -82,4 +82,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/dft/skills/dft/SKILL.md
+++ b/plugins/dft/skills/dft/SKILL.md
@@ -216,4 +216,6 @@ write or overwrite one JSON record in `memory/dft/experiences.jsonl` keyed by
 without full orchestrator context.
 
 Use `run_id` = `dft_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+stage update). Every JSON record written must include a top-level `"run_id"` field
+whose value matches this key — reject or regenerate if missing before writing. Set
+`signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/dft/skills/dft/SKILL.md
+++ b/plugins/dft/skills/dft/SKILL.md
@@ -204,3 +204,16 @@ chip meets quality targets (fault coverage and DPPM).
 - Final test pattern files
 - BSDL file
 - DFT netlist (input to PD)
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/dft/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `dft_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -46,7 +46,7 @@ bsp_development → peripheral_drivers → rtos_integration → driver_validatio
 2. Do not proceed to rtos_integration until ALL drivers pass unit tests
 3. Track drivers_complete[] in state — partial driver list blocks RTOS stage
 4. Output: validated firmware package + bring-up guide + known issues list
-5. Read `memory/firmware/knowledge.md` before the first stage and write an experience record to `memory/firmware/experiences.jsonl` after signoff or escalation.
+5. Read `memory/firmware/knowledge.md` before the first stage. Write an experience record to `memory/firmware/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -79,4 +79,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/firmware/skills/embedded-firmware/SKILL.md
+++ b/plugins/firmware/skills/embedded-firmware/SKILL.md
@@ -220,3 +220,16 @@ void     PERIPH_HandleIRQ(PERIPH_Type *base, periph_handle_t *handle);
 - Test results report
 - Bring-up guide for silicon team
 - Known issues list
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/firmware/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `firmware_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -64,10 +64,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/formal/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "formal",
   "design_name": "<from state>",

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -53,7 +53,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. CEX from RTL bug: suspend, report to RTL team, wait for fix confirmation before retry
 3. Flag any unproven P0 property as a hard blocker for sign-off
 4. Vacuity check required after every environment_setup iteration
-5. Read `memory/formal/knowledge.md` before the first stage and write an experience record to `memory/formal/experiences.jsonl` after signoff or escalation.
+5. Read `memory/formal/knowledge.md` before the first stage. Write an experience record to `memory/formal/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -86,4 +86,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/formal/skills/formal-verification/SKILL.md
+++ b/plugins/formal/skills/formal-verification/SKILL.md
@@ -203,3 +203,16 @@ assume property (@(posedge clk)
 - Formal sign-off report
 - Final property status table
 - LEC clean record
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/formal/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `formal_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/formal/skills/formal-verification/SKILL.md
+++ b/plugins/formal/skills/formal-verification/SKILL.md
@@ -215,4 +215,7 @@ write or overwrite one JSON record in `memory/formal/experiences.jsonl` keyed by
 without full orchestrator context.
 
 Use `run_id` = `formal_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+stage update). Every JSON record written must include a top-level `"run_id"` field
+whose value matches this key — stage writes must upsert/overwrite by matching this
+persisted `run_id`. Set `signoff_achieved: false` until the final sign-off stage
+completes.

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -57,7 +57,7 @@ When invoking open-source tools, follow the execution hierarchy:
 3. SW bugs: fix in firmware without re-synthesising unless HW root cause confirmed
 4. All performance measurements: record at prototype frequency with scale factor noted
 5. Output: prototype sign-off report + HW bug report for RTL team + performance baseline
-6. Read `memory/fpga/knowledge.md` before the first stage and write an experience record to `memory/fpga/experiences.jsonl` after signoff or escalation.
+6. Read `memory/fpga/knowledge.md` before the first stage. Write an experience record to `memory/fpga/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -90,4 +90,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/fpga/skills/fpga-emulation/SKILL.md
+++ b/plugins/fpga/skills/fpga-emulation/SKILL.md
@@ -240,8 +240,25 @@ After each stage completes (regardless of whether an orchestrator session is act
 append one newline-delimited JSON object to `memory/fpga/experiences.jsonl`. Do not
 rewrite the file; always append. Consumers dedup by `run_id` on read (last-seen wins).
 
-Use `run_id` = `fpga_<YYYYMMDD>_<HHMMSS>_<6-char-random>` (generated once at flow
-start using a short random suffix to avoid collisions; reuse on each stage append).
-Every appended record must include the top-level `"run_id"` field. Set
-`signoff_achieved: false` on all stage appends; set to `true` only in the final
-sign-off stage append for the matching `run_id`.
+Use `run_id` = `fpga_<YYYYMMDD>_<HHMMSS>_<6-char-random>` where the 6-character suffix
+is a lowercase hexadecimal string `[0-9a-f]` generated once at flow start using a secure
+or pseudorandom RNG and reused unchanged on every stage append for this run.
+
+Each appended record must conform to the following schema:
+```json
+{
+  "run_id":           "fpga_20260418_143052_a3f7b1",
+  "stage":            "<stage_name>",
+  "timestamp":        "<ISO-8601>",
+  "signoff_achieved": false,
+  "outcomes":         { "<key>": "<value>" },
+  "metrics":          { "<key>": "<value>" },
+  "tools":            [{ "name": "<tool>", "version": "<version>", "result": "<pass|fail>" }],
+  "notes":            "<optional free-text>"
+}
+```
+
+Field types: `run_id` and `stage` are non-empty strings; `timestamp` is ISO-8601;
+`signoff_achieved` is a boolean (`false` for all stage appends; `true` only in the final
+sign-off append for the matching `run_id`); `outcomes` and `metrics` are objects; `tools`
+is an array of objects; `notes` is an optional string.

--- a/plugins/fpga/skills/fpga-emulation/SKILL.md
+++ b/plugins/fpga/skills/fpga-emulation/SKILL.md
@@ -230,3 +230,16 @@ provides functional and architectural validation months before silicon.
 - Bug report for RTL team (HW bugs with ILA evidence)
 - Performance baseline document
 - Prototype user guide for SW development team
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/fpga/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `fpga_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/fpga/skills/fpga-emulation/SKILL.md
+++ b/plugins/fpga/skills/fpga-emulation/SKILL.md
@@ -237,9 +237,11 @@ provides functional and architectural validation months before silicon.
 
 ### Write on stage completion
 After each stage completes (regardless of whether an orchestrator session is active),
-write or overwrite one JSON record in `memory/fpga/experiences.jsonl` keyed by
-`run_id`. This ensures data is persisted even if the flow is interrupted or called
-without full orchestrator context.
+append one newline-delimited JSON object to `memory/fpga/experiences.jsonl`. Do not
+rewrite the file; always append. Consumers dedup by `run_id` on read (last-seen wins).
 
-Use `run_id` = `fpga_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+Use `run_id` = `fpga_<YYYYMMDD>_<HHMMSS>_<6-char-random>` (generated once at flow
+start using a short random suffix to avoid collisions; reuse on each stage append).
+Every appended record must include the top-level `"run_id"` field. Set
+`signoff_achieved: false` on all stage appends; set to `true` only in the final
+sign-off stage append for the matching `run_id`.

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -54,7 +54,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track hls_report metrics (latency, II, area) in state across iterations
 3. Co-simulation output mismatch is always a blocker — root cause before retry
 4. Output: HLS RTL package + co-sim report + interface documentation
-5. Read `memory/hls/knowledge.md` before the first stage and write an experience record to `memory/hls/experiences.jsonl` after signoff or escalation.
+5. Read `memory/hls/knowledge.md` before the first stage. Write an experience record to `memory/hls/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -87,4 +87,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -65,10 +65,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/hls/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "hls",
   "design_name": "<from state>",

--- a/plugins/hls/skills/hls/SKILL.md
+++ b/plugins/hls/skills/hls/SKILL.md
@@ -209,3 +209,16 @@ and co-simulation to verify RTL matches the golden C model.
 - Co-simulation pass report
 - HLS QoR report (latency, II, area)
 - Interface documentation
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/hls/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `hls_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/hls/skills/hls/SKILL.md
+++ b/plugins/hls/skills/hls/SKILL.md
@@ -221,4 +221,6 @@ write or overwrite one JSON record in `memory/hls/experiences.jsonl` keyed by
 without full orchestrator context.
 
 Use `run_id` = `hls_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+stage update). Every JSON record written must include a top-level `"run_id"` field
+whose value matches this key — this is what makes overwrites unambiguous. Set
+`signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -65,7 +65,7 @@ placed/routed, prefer:
 2. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
 3. Never proceed past a FAIL without applying the loop-back rule
 4. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report
-5. Read `memory/pd/knowledge.md` before the first stage and write an experience record to `memory/pd/experiences.jsonl` after signoff or escalation.
+5. Read `memory/pd/knowledge.md` before the first stage. Write an experience record to `memory/pd/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -99,4 +99,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -76,10 +76,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/pd/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "pd",
   "design_name": "<from state>",

--- a/plugins/pd/skills/physical-design/SKILL.md
+++ b/plugins/pd/skills/physical-design/SKILL.md
@@ -283,3 +283,16 @@ Resume from step: `openlane --from <step_name> <config.json>`
 - LVS clean report
 - Final GDS-II
 - Completed tape-out checklist
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/pd/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `pd_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -55,7 +55,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Enforce SystemVerilog coding standards from skill at every rtl_coding stage
 3. Escalate clearly if max iterations exceeded — show state and root cause
 4. Output: RTL package (filelist.f, all .sv files, assertions, lint/CDC reports)
-5. Read `memory/rtl-design/knowledge.md` before the first stage and write an experience record to `memory/rtl-design/experiences.jsonl` after signoff or escalation.
+5. Read `memory/rtl-design/knowledge.md` before the first stage. Write an experience record to `memory/rtl-design/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -88,4 +88,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/rtl-design/skills/rtl-design/SKILL.md
+++ b/plugins/rtl-design/skills/rtl-design/SKILL.md
@@ -203,3 +203,16 @@ and synthesis handoff.
 - Compile order document
 - Assertion library (.sva files)
 - RTL sign-off record
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/rtl-design/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `rtl-design_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -64,10 +64,11 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), append one JSON line to
+After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `memory/soc/experiences.jsonl`:
 ```json
 {
+  "run_id": "<from state>",
   "timestamp": "<ISO-8601>",
   "domain": "soc",
   "design_name": "<from state>",

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -53,7 +53,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Block progression if any IP has unresolved qualification issues
 3. Track ip_status{} per IP in state — never proceed with unqualified IP
 4. Output: integrated SoC RTL package ready for synthesis
-5. Read `memory/soc/knowledge.md` before the first stage and write an experience record to `memory/soc/experiences.jsonl` after signoff or escalation.
+5. Read `memory/soc/knowledge.md` before the first stage. Write an experience record to `memory/soc/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -86,4 +86,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -61,11 +61,13 @@ When invoking open-source tools, follow the execution hierarchy:
 Before beginning `ip_procurement`, read `memory/soc/knowledge.md` if it exists.
 Incorporate its guidance into stage decisions — especially known failure patterns,
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
-without it.
+without it. Also initialise `state.run_id` to `soc_<YYYYMMDD>_<HHMMSS>` at this
+point; all subsequent stage writes and upsert operations must reference this value.
 
 ### Write (session end)
-After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
-`memory/soc/experiences.jsonl`:
+On any termination path (signoff, escalation, abandon, interruption, error, or max-turns), upsert
+(create or replace by `run_id`) one JSON line in `memory/soc/experiences.jsonl` immediately with
+the current stage state:
 ```json
 {
   "run_id": "<from state>",
@@ -87,5 +89,4 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
   "notes": "<free-text observations>"
 }
 ```
-If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/soc/skills/soc-integration/SKILL.md
+++ b/plugins/soc/skills/soc-integration/SKILL.md
@@ -207,3 +207,16 @@ integration, and chip-level simulation sign-off.
 - Integration sign-off report
 - Final memory map document
 - Integrated SoC RTL package (ready for synthesis)
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/soc/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `soc_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -60,7 +60,7 @@ highest-value MCP use case in the entire flow.
 3. LEC required after every ECO batch — do not accumulate ECOs without equivalence check
 4. ECO count > 2% of cells: hard stop, escalate to physical design team
 5. Do not enter eco_guidance if any exception in exception_review is pending sign-off — block until resolved
-6. Read `memory/sta/knowledge.md` before the first stage and write an experience record to `memory/sta/experiences.jsonl` after signoff or escalation.
+6. Read `memory/sta/knowledge.md` before the first stage. Write an experience record to `memory/sta/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -94,4 +94,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/sta/skills/sta/SKILL.md
+++ b/plugins/sta/skills/sta/SKILL.md
@@ -232,3 +232,16 @@ Hold violation:
 - Sign-off timing report (all corners, all modes)
 - ECO change summary
 - Timing sign-off record
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/sta/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `sta_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -50,7 +50,7 @@ When invoking open-source tools, follow the execution hierarchy:
 1. Read logic-synthesis skill before each stage
 2. On completion: produce PD handoff package (netlist, SDC, timing/area/power reports)
 3. LEC must be run after every netlist change — not just at sign-off
-4. Read `memory/synthesis/knowledge.md` before the first stage and write an experience record to `memory/synthesis/experiences.jsonl` after signoff or escalation.
+4. Read `memory/synthesis/knowledge.md` before the first stage. Write an experience record to `memory/synthesis/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -84,4 +84,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/synthesis/skills/logic-synthesis/SKILL.md
+++ b/plugins/synthesis/skills/logic-synthesis/SKILL.md
@@ -190,3 +190,16 @@ When used inside OpenROAD Flow Scripts (ORFS) or LibreLane, the Yosys log appear
 
 ### Output Required
 - PD handoff package: netlist, SDC, timing reports, area/power reports
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/synthesis/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `synthesis_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.

--- a/plugins/synthesis/skills/logic-synthesis/SKILL.md
+++ b/plugins/synthesis/skills/logic-synthesis/SKILL.md
@@ -197,9 +197,10 @@ When used inside OpenROAD Flow Scripts (ORFS) or LibreLane, the Yosys log appear
 
 ### Write on stage completion
 After each stage completes (regardless of whether an orchestrator session is active),
-write or overwrite one JSON record in `memory/synthesis/experiences.jsonl` keyed by
-`run_id`. This ensures data is persisted even if the flow is interrupted or called
-without full orchestrator context.
-
-Use `run_id` = `synthesis_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+upsert one JSON record in `memory/synthesis/experiences.jsonl` keyed by `run_id`.
+Implement the upsert by rewriting the file: read all existing lines, filter out any
+record(s) with the same `run_id`, append the updated record, write the full content
+back atomically (replace the file). Every record must include a top-level `"run_id"`
+field with format `synthesis_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on
+each stage update). Set `signoff_achieved: false` until the final sign-off stage
+completes.

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -54,7 +54,7 @@ When invoking open-source tools, follow the execution hierarchy:
 2. Track all bugs in state bugs_found[] — do not discard between stages
 3. Do not proceed to regression_signoff if any P0/P1 bugs remain open
 4. Bug found during directed tests: suspend flow; present RTL fix required report
-5. Read `memory/verification/knowledge.md` before the first stage and write an experience record to `memory/verification/experiences.jsonl` after signoff or escalation.
+5. Read `memory/verification/knowledge.md` before the first stage. Write an experience record to `memory/verification/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 
 ## Memory
 
@@ -87,4 +87,5 @@ After signoff (or on escalation/abandon), append one JSON line to
   "notes": "<free-text observations>"
 }
 ```
+If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.

--- a/plugins/verification/skills/functional-verification/SKILL.md
+++ b/plugins/verification/skills/functional-verification/SKILL.md
@@ -280,3 +280,16 @@ priority:     P0
 - Final merged coverage report
 - Open bug list
 - Sign-off checklist
+
+---
+
+## Memory
+
+### Write on stage completion
+After each stage completes (regardless of whether an orchestrator session is active),
+write or overwrite one JSON record in `memory/verification/experiences.jsonl` keyed by
+`run_id`. This ensures data is persisted even if the flow is interrupted or called
+without full orchestrator context.
+
+Use `run_id` = `verification_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
+stage update). Set `signoff_achieved: false` until the final sign-off stage completes.


### PR DESCRIPTION
## 📌 Description
Agent memory will not be updated during these 2 loopholes
- Orchestrator exits when it is neither signoff nor escalation
- Direct agent invocation without Orchestrator - It cooperates with the bounded request and never reaches the exit conditions

## 🔗 Related Issue
NIL

## 🧪 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement / refactor
- [ ] Documentation update

## 🧠 What Changed?
- Increase exit conditions to be more diverse
  - From only signoff or escalation to whenever flow terminates
- Include a write on stage completion so that data is persisted even when flow is interrupted

## 🔄 Affected Areas
- [x] Agent logic
- [ ] Workflow orchestration
- [ ] Scripts / tooling
- [ ] Documentation
- [ ] Other:

## ⚙️ How to Test
Provide a clear way to validate this PR:

1. Validate that all agent and skill MD files contain the relevant key-phrases to trigger the memory write
2. Invoke orchestrator with real/mock design task, interrupt it mid-flow and check if the memory file is created with partial record

## 📦 Outputs / Results
Describe any generated outputs or observable changes:
- Memory file will be generated if modified prompt is working as expected

## ⚠️ Risks / Notes
NIL

## ✅ Checklist
- [x] Changes are scoped and minimal
- [x] Verified functionality manually or via tests
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

## 📎 Additional Context
NIL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Experience logging now records session data on any flow termination (including errors, interruptions, max-iterations), and writes immediately for premature endings.
  * Persistence changed to update a single record per session (upsert) so stage progress is kept current rather than only appending.
  * Added a standardized run_id format and a signoff_achieved flag to track session identity and completion state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->