### PR TITLE
Add module_discovery stage and per-tool install scripts

### DIFF
--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -43,7 +43,7 @@ tool_discovery → module_discovery → tool_installation → wrapper_deployment
 - tool_installation FAIL (python3 missing)                      → escalate immediately (python3 required for all wrappers)
 - tool_installation FAIL (python3 module not loaded)            → escalate: "Python available via module `<python_env.module_name>` — source load-modules.sh then re-run"
 - module_discovery WARN (module system not found)               → proceed (module system is optional)
-- module_discovery FAIL (listing command error)                 → proceed with WARN logged (non-fatal)
+- module_discovery WARN (listing command error)                 → proceed (non-fatal; downgrade to WARN since module system is optional)
 - environment_validation FAIL (python_env.type == module, module unloaded) → escalate: "Python environment not active — source load-modules.sh (module: <python_env.module_name>) and re-run environment_validation"
 - environment_validation FAIL (critical tool MISSING)           → tool_installation    (max 2×)
 - environment_validation WARN (critical tool MISSING_LOAD_MODULE)    → escalate: instruct user to source load-modules.sh and re-run

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -3,8 +3,8 @@ name: infrastructure-orchestrator
 description: >
   Orchestrates EDA tool detection, output-filtering wrapper deployment, and MCP
   server configuration. Invoke when setting up a chip-design environment, verifying
-  tool availability before running a domain orchestrator, or generating
-  install-missing-tools.sh for a new workstation.
+  tool availability before running a domain orchestrator, or generating per-tool
+  install scripts with TCL modulefiles for a new workstation.
 model: sonnet
 effort: high
 maxTurns: 40
@@ -20,7 +20,7 @@ configure MCP server templates — so every downstream domain orchestrator recei
 compact JSON instead of raw 10,000–50,000-line tool logs.
 
 ## Stage Sequence
-tool_discovery → tool_installation → wrapper_deployment → mcp_configuration → environment_validation
+tool_discovery → module_discovery → tool_installation → wrapper_deployment → mcp_configuration → environment_validation
 
 ## Tool Options
 
@@ -30,14 +30,23 @@ tool_discovery → tool_installation → wrapper_deployment → mcp_configuratio
 - KLayout (`klayout`), OpenSTA (`sta`), SymbiYosys (`sby`)
 - gem5 (`gem5`), Bambu HLS (`bambu-hls`), nextpnr (`nextpnr`), openFPGALoader (`openFPGALoader`)
 - cocotb (Python package), LLVM (`llvm-config`), GCC (`gcc`), OpenOCD (`openocd`)
+- xschem (`xschem`), GTKWave (`gtkwave`), uv (`uv`)
 
 ### Proprietary (detect only — never install)
 - Synopsys VCS, Cadence Xcelium, Synopsys Design Compiler
 - Cadence Innovus, Mentor QuestaSim, Synopsys PrimeTime, Synopsys Formality
 
+> Proprietary tools not found in PATH may still be available via TCL Environment Modules.
+> The `module_discovery` stage enumerates available versions and generates `load-modules.sh`.
+
 ## Loop-Back Rules
 - tool_installation FAIL (python3 missing)                      → escalate immediately (python3 required for all wrappers)
-- environment_validation FAIL (critical tool missing)           → tool_installation    (max 2×)
+- tool_installation FAIL (python3 module not loaded)            → escalate: "Python available via module `<python_env.module_name>` — source load-modules.sh then re-run"
+- module_discovery WARN (module system not found)               → proceed (module system is optional)
+- module_discovery FAIL (listing command error)                 → proceed with WARN logged (non-fatal)
+- environment_validation FAIL (python_env.type == module, module unloaded) → escalate: "Python environment not active — source load-modules.sh (module: <python_env.module_name>) and re-run environment_validation"
+- environment_validation FAIL (critical tool MISSING)           → tool_installation    (max 2×)
+- environment_validation WARN (critical tool MISSING_LOAD_MODULE)    → escalate: instruct user to source load-modules.sh and re-run
 - wrapper_deployment FAIL (permission denied)                   → escalate with `sudo chmod +x plugins/infrastructure/tools/*.sh`
 
 ## State Object
@@ -48,6 +57,7 @@ Initialise and maintain this JSON state across all stages:
   "host": "<from environment>",
   "stages": {
     "tool_discovery":        { "status": "pending", "output": {} },
+    "module_discovery":      { "status": "pending", "output": {} },
     "tool_installation":     { "status": "pending", "output": {} },
     "wrapper_deployment":    { "status": "pending", "output": {} },
     "mcp_configuration":     { "status": "pending", "output": {} },
@@ -55,9 +65,18 @@ Initialise and maintain this JSON state across all stages:
   },
   "tools_found": [],
   "tools_missing": [],
+  "python_env": {
+    "exec": null,
+    "type": null,
+    "bin_dir": null,
+    "module_name": null
+  },
+  "module_system": null,
+  "tools_via_modules": [],
   "wrappers_deployed": 0,
   "mcp_servers_configured": 0,
   "mcp_target": 10,
+  "install_scripts_generated": 0,
   "loop_count": {},
   "current_stage": null,
   "flow_status": "not_started"
@@ -73,6 +92,8 @@ Each stage must return:
   "qor": {
     "tools_detected": 0,
     "tools_missing": 0,
+    "module_system_detected": false,
+    "tools_found_via_modules": 0,
     "wrappers_deployed": 0,
     "mcp_servers_configured": 0
   },
@@ -86,5 +107,5 @@ Each stage must return:
 1. Read the infrastructure skill before executing each stage
 2. Enforce loop-back rules strictly — do not proceed past a FAIL
 3. If max iterations exceeded: stop, present full state and escalation report
-4. Never auto-run `install-missing-tools.sh` — present it to the user for review
+4. Never auto-run per-tool install scripts — present them to the user for review; each MISSING tool gets its own `install-<toolname>.sh` written to `install-missing-tools/`
 5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, `mcp-adapter.py` and `mcp-session-adapter.py` present, and all 10 MCP config snippets written with resolved absolute paths and printed

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -3,7 +3,8 @@ name: infrastructure
 description: >
   EDA tool detection, wrapper deployment, and MCP configuration for digital chip
   design environments. Use when setting up a new workstation, verifying tool
-  availability before a domain flow, or generating install-missing-tools.sh.
+  availability before a domain flow, or generating per-tool install scripts with
+  TCL modulefiles.
 version: 1.0.0
 author: chuanseng-ng
 license: MIT
@@ -55,6 +56,9 @@ complete environment before any domain orchestrator begins work.
 - **LLVM** (`llvm-config`) — compiler infrastructure
 - **GCC** (`gcc`) — GNU compiler collection
 - **OpenOCD** (`openocd`) — on-chip debugger
+- **xschem** (`xschem`) — schematic capture and simulation netlist tool
+- **GTKWave** (`gtkwave`) — waveform viewer for VCD/FST simulation output
+- **uv** (`uv`) — fast Python package and project manager (required for cocotb installs)
 
 ### Proprietary (detect only — never install)
 - **Synopsys VCS** (`vcs`) — industry-standard RTL simulator
@@ -123,12 +127,48 @@ before falling back to the wrapper or direct execution.
 
 ### Domain Rules
 1. Run `which <command>` and `<command> --version` (or `-version`) for every open-source tool
-2. **Exception — Python packages**: for `cocotb`, use `cocotb-config --version` (not `which cocotb`) to determine FOUND and capture the version string; report MISSING if `cocotb-config` is absent or returns non-zero
-3. For proprietary tools: check PATH using `which <primary-executable>` only (see executable names in the Proprietary section above); never attempt install; record as `PROPRIETARY_ONLY` if found, `MISSING` otherwise
-4. Record each tool as one of: `FOUND`, `MISSING`, or `PROPRIETARY_ONLY`
-5. Capture exact version string for each `FOUND` tool
-6. Never attempt installation in this stage
-7. Write results to `tool-status.json` before advancing
+2. **Python interpreter detection** — run once at the start of tool_discovery, before checking any Python packages. Detection order (first match wins):
+
+   **Step A — Module system probe (runs before PATH check)**:
+   a. Check if a module system is available: test `$MODULESHOME` is set OR `modulecmd` exists in PATH.
+   b. If a module system is available, run `module avail 2>&1` and search for entries matching `python` or `python3` (case-insensitive).
+   c. If one or more Python module entries are found: select the latest version (highest semver/lexicographic), load it via `module load <python-module>`, then run `which python3` to resolve `PYTHON_EXEC`. Set `python_env.type = "module"` and record `python_env.module_name` with the loaded module name. **Keep the module loaded for the entire orchestrator run** — do not unload it; subsequent stages (tool_installation, wrapper_deployment, environment_validation) all depend on `PYTHON_EXEC` being resolvable. The generated `load-modules.sh` handles persistent loading for future shell sessions.
+   d. If no module system is available, or no Python module entries are found: proceed to Step B.
+
+   **Step B — PATH-based fallback**:
+   e. Run `which python3` to get the interpreter path; store as `PYTHON_EXEC`.
+   f. If `which python3` fails or returns empty: record `python3` as `MISSING` in `tool-status.json` and FAIL immediately (required for all wrapper scripts and Python packages).
+   g. Classify the interpreter:
+      - `system` → `PYTHON_EXEC` == `/usr/bin/python3`
+      - `custom` → any other path (pyenv, conda, virtualenv, custom prefix, etc.)
+
+   **Step C — Finalize**:
+   h. Set `PYTHON_BIN_DIR = $(dirname "$PYTHON_EXEC")` regardless of how `PYTHON_EXEC` was resolved.
+   i. Record under a top-level key `python_env` in `tool-status.json`:
+      ```json
+      {
+        "python_env": {
+          "exec": "<absolute path>",
+          "type": "module | system | custom",
+          "bin_dir": "<absolute dir>",
+          "module_name": "<module name, or null if not module-based>"
+        }
+      }
+      ```
+   j. Capture `"$PYTHON_EXEC" --version` and store it as a regular entry in the `tools` array (with `"tool": "python3"`, `"command": "python3"`, `"status": "FOUND"`, `"version": "<output>"`, `"path": "<PYTHON_EXEC>"`). This makes `python3` visible to `module_discovery` for module-status upgrades (`FOUND_PREFER_MODULE`).
+
+3. **Exception — Python packages**:
+   - **cocotb**: detection depends on the Python interpreter type determined in rule 2:
+     - If `python_env.type == "custom"` or `"module"`: check `"$PYTHON_BIN_DIR/cocotb-config" --version` first; if that exits zero, record FOUND with the returned version string. Only if absent or non-zero, fall back to `cocotb-config --version` (PATH-based).
+     - If `python_env.type == "system"`: use `cocotb-config --version` (PATH-based) only.
+     - Report MISSING if all attempted checks fail.
+   - **openlane**: run `"$PYTHON_EXEC" -m pip show openlane 2>/dev/null`; if exit code 0 and `Name: openlane` appears in output, record FOUND and extract the `Version:` field; otherwise MISSING.
+   - **uv**: if `python_env.type == "custom"` or `"module"`: check `"$PYTHON_BIN_DIR/uv" --version` first; fall back to `uv --version` (PATH). If `python_env.type == "system"`: use `uv --version` only.
+4. For proprietary tools: check PATH using `which <primary-executable>` only (see executable names in the Proprietary section above); never attempt install; record as `PROPRIETARY_ONLY` if found, `MISSING` otherwise
+5. Record each tool as one of: `FOUND`, `MISSING`, or `PROPRIETARY_ONLY`
+6. Capture exact version string for each `FOUND` tool
+7. Never attempt installation in this stage
+8. Write results to `tool-status.json` before advancing
 
 ### QoR Metrics to Evaluate
 - `tools_detected`: count of FOUND tools (target ≥ 10 for a functional open-source flow)
@@ -136,21 +176,153 @@ before falling back to the wrapper or direct execution.
 - `proprietary_found`: count of PROPRIETARY_ONLY tools detected in PATH
 
 ### Output Required
-- `tool-status.json` — array of `{ "tool": "", "command": "", "status": "FOUND|MISSING|PROPRIETARY_ONLY", "version": "", "path": "" }`
+- `tool-status.json` — contains two top-level keys:
+  - `python_env`: `{ "exec": "", "type": "module|system|custom", "bin_dir": "", "module_name": "" }` — populated by rule 2
+  - `tools`: array of `{ "tool": "", "command": "", "status": "FOUND|MISSING|PROPRIETARY_ONLY", "version": "", "path": "" }`
+
+Note: module-based availability (`FOUND_PREFER_MODULE`, `MISSING_LOAD_MODULE`) and the `module_names`/`versions_available` fields are added in the next stage (`module_discovery`).
+
+---
+
+## Stage: module_discovery
+
+### Domain Rules
+
+#### Module system detection (in order of preference)
+1. **Classic Environment Modules (TCL)** — check `$MODULESHOME` is set, or `modulecmd` binary exists in PATH
+2. **Neither** — set `module_system: "none"`, emit WARN, skip remaining rules, write empty `module-status.json`, advance to `tool_installation`
+
+#### Module listing commands
+- **Classic**: `module avail 2>&1` — parse text; entries appear as `<name>/<version>`
+- If the listing command exits non-zero: emit WARN, record the error, proceed
+
+#### Module-to-tool mapping table
+
+| Tool command | Module name patterns to match (case-insensitive substring) |
+|---|---|
+| `vcs` | `vcs`, `synopsys-vcs`, `synopsys/vcs` |
+| `xrun` | `xcelium`, `cadence-xcelium`, `cadence/xcelium` |
+| `dc_shell` | `design-compiler`, `synopsys/dc`, `dc_shell` |
+| `innovus` | `innovus`, `cadence/innovus`, `cadence-innovus` |
+| `vsim` | `questa`, `questasim`, `mentor/questa` |
+| `pt_shell` | `primetime`, `synopsys/pt`, `pt_shell` |
+| `formality` | `formality`, `synopsys/formality` |
+| `verilator` | `verilator` |
+| `yosys` | `yosys` |
+| `openroad` | `openroad` |
+| `klayout` | `klayout` |
+| `iverilog` | `icarus`, `iverilog` |
+| `sta` | `opensta` |
+| `gcc` | `gcc` |
+| `llvm-config` | `llvm` |
+| `xschem` | `xschem` |
+| `gtkwave` | `gtkwave` |
+| `uv` | `uv` |
+| `python3` | `python`, `python3` |
+| `slang` | `slang` |
+| `surelog` | `surelog` |
+| `sv2v` | `sv2v` |
+| `sby` | `symbiyosys`, `sby`, `yosyshq/sby` |
+| `bambu-hls` | `bambu`, `bambu-hls`, `panda-bambu` |
+| `nextpnr` | `nextpnr` |
+| `openFPGALoader` | `openfpgaloader` |
+| `openocd` | `openocd` |
+
+#### Rules
+1. Detect module system using the detection order above
+2. Run the appropriate listing command for the detected system
+3. For each entry in the listing, test against the mapping table (case-insensitive)
+4. For each matched tool, collect all available version strings
+5. Write `module-status.json` before advancing
+6. For each tool marked `FOUND` in `tool-status.json` that also has a module available: change status to `FOUND_PREFER_MODULE`, add `module_names` and `versions_available` fields, include in `load-modules.sh` — module takes precedence over PATH version
+7. For each tool marked `MISSING` in `tool-status.json` that has modules available: change status to `MISSING_LOAD_MODULE`, add `module_names` and `versions_available` fields
+8. Generate `load-modules.sh` for all `FOUND_PREFER_MODULE` and `MISSING_LOAD_MODULE` tools; default to the latest version (highest semver/lexicographic); comment out alternative versions inline
+9. Never auto-run `load-modules.sh` — print: "Review and source `load-modules.sh` to load EDA modules, then re-run the flow"
+
+#### Extended `tool-status.json` schema
+Fields added by this stage to each entry in the `tools` array (backward-compatible additions):
+```json
+{
+  "tool": "",
+  "command": "",
+  "status": "FOUND | FOUND_PREFER_MODULE | MISSING | MISSING_LOAD_MODULE | PROPRIETARY_ONLY",
+  "version": "",
+  "path": "",
+  "module_names": [],
+  "versions_available": []
+}
+```
+
+Note: The top-level `python_env` object is **preserved unchanged** during this stage — only entries in the `tools` array are modified. The `python3` tool entry is treated like any other: if `python_env.type == "module"`, its `tools` array status is upgraded from `FOUND` to `FOUND_PREFER_MODULE` and it is included in `load-modules.sh`.
+
+### QoR Metrics to Evaluate
+- `module_system_detected`: bool — true if classic Environment Modules (TCL) found
+- `tools_found_via_modules`: count of tools with status `MISSING_LOAD_MODULE` or `FOUND_PREFER_MODULE`
+
+### Stage Output Summary
+Print a human-readable table before advancing:
+```
+Module system : Environment Modules 4.8.0 (TCL)
+Tools in PATH : 12
+Tools via modules : 5
+  vcs        — synopsys/vcs/2020.03, synopsys/vcs/2021.01
+  xrun       — cadence/xcelium/20.09
+  dc_shell   — synopsys/dc/2022.03
+  innovus    — cadence/innovus/21.1
+  pt_shell   — synopsys/primetime/2022.06
+```
+
+### Output Required
+- `module-status.json` — module system details and per-tool module listings
+- Updated `tool-status.json` — statuses and module fields added for matched tools
+- `load-modules.sh` — generated when any tool has status `FOUND_PREFER_MODULE` or `MISSING_LOAD_MODULE`; omitted when `module_system` is `"none"`
+
+`module-status.json` schema:
+```json
+{
+  "module_system": "tclmod | none",
+  "module_system_version": "",
+  "tools_via_modules": [
+    {
+      "tool": "<command>",
+      "module_names": ["synopsys/vcs/2020.03", "synopsys/vcs/2021.01"],
+      "versions_available": ["2020.03", "2021.01"]
+    }
+  ]
+}
+```
+
+`load-modules.sh` format:
+```bash
+#!/usr/bin/env bash
+# Generated by module_discovery — source this file to load EDA tool modules
+# Usage: source load-modules.sh
+
+module load synopsys/vcs/2021.01       # latest; alternatives: 2020.03
+module load cadence/xcelium/20.09
+# module load cadence/innovus/21.1     # uncomment if needed
+```
 
 ---
 
 ## Stage: tool_installation
 
 ### Domain Rules
-1. **Never auto-run installs** — only generate `install-missing-tools.sh`
-2. Script must include package-manager commands for each missing tool:
-   - apt-get (Ubuntu/Debian), brew (macOS), pacman (Arch) where available
-   - fall back to build-from-source instructions when no package exists
-3. Mark proprietary tools as "# manual install required — see vendor docs"
-4. If `python3` is missing: FAIL immediately and escalate — required for wrappers
-5. Include `chmod +x` calls for all wrapper scripts at the end of the install script
-6. Write `tool-manifest.json` reflecting confirmed tool state after user runs the script
+1. **Never auto-run installs** — only generate per-tool install scripts
+2. If `python3` is missing: FAIL immediately and escalate — required for all wrapper scripts
+3. Generate one `install-<toolname>.sh` for every tool with status `MISSING`; skip tools with status `FOUND`, `FOUND_PREFER_MODULE`, `MISSING_LOAD_MODULE`, or `PROPRIETARY_ONLY`
+4. Each script follows the Per-Tool Script Structure below
+5. Use the Package Name Mapping Table to emit correct install commands for the detected OS/PM
+6. **Python package install scripts** (`openlane`, `cocotb`, `uv`): read `python_env.exec` from `tool-status.json` and substitute it for `<PYTHON_EXEC>` (and `python_env.bin_dir` for `<PYTHON_BIN_DIR>`). At the top of each Python package install script, emit:
+    ```bash
+    PYTHON_EXEC="<value of python_env.exec>"
+    # Verify this is the intended interpreter before running
+    ```
+    Use `"$PYTHON_EXEC" -m pip install <package>` as the install command. Never use bare `pip install` when `python_env.type` is `"custom"` or `"module"`.
+7. Proprietary tools: no script generated — record a note in the sign-off summary only
+8. Modulefile format: always TCL classic (no file extension); if `module_system == "none"`, emit WARN and skip modulefile generation
+9. Each script must end with guidance for registering `$EDA_MODULEFILES_ROOT` in `$MODULEPATH` if not already present
+10. Write all `install-<toolname>.sh` scripts to the `install-missing-tools/` directory; create the directory if it does not exist; do **not** create the directory or any scripts if no tools are `MISSING`
 
 ### Common Issues & Fixes
 
@@ -160,9 +332,108 @@ before falling back to the wrapper or direct execution.
 | OpenROAD build required | Refer to https://github.com/The-OpenROAD-Project/OpenROAD |
 | Bambu HLS Linux only | Wrap with `status: WARN` on macOS/Windows |
 
+### Install Directory Layout
+
+```
+$EDA_TOOLS_ROOT/                         (default: /tools)
+  <toolname>/<version>/                  e.g. /tools/verilator/5.028/
+    bin/
+    lib/
+    share/
+
+$EDA_MODULEFILES_ROOT/                   (default: /tools/toolmgr/env/modulefiles)
+  <toolname>/<version>                   e.g. /tools/toolmgr/env/modulefiles/verilator/5.028
+```
+
+Both roots are read from env vars at script runtime with the defaults above.
+
+### Per-Tool Script Structure
+
+Each `install-<toolname>.sh` — file: `$EDA_MODULEFILES_ROOT/<toolname>/<version>` (TCL, no extension):
+
+```bash
+#!/usr/bin/env bash
+# install-<toolname>.sh — generated by infrastructure-orchestrator
+# Installs <Tool Full Name> to $EDA_TOOLS_ROOT/<toolname>/<version>
+# and generates a TCL modulefile at $EDA_MODULEFILES_ROOT/<toolname>/<version>
+set -euo pipefail
+
+TOOL_NAME="<toolname>"
+TOOL_VERSION="<detected-or-latest>"
+EDA_TOOLS_ROOT="${EDA_TOOLS_ROOT:-/tools}"
+EDA_MODULEFILES_ROOT="${EDA_MODULEFILES_ROOT:-/tools/toolmgr/env/modulefiles}"
+INSTALL_DIR="${EDA_TOOLS_ROOT}/${TOOL_NAME}/${TOOL_VERSION}"
+
+# --- Install ---
+# Build-from-source: pass --prefix="${INSTALL_DIR}" to configure/cmake
+# Package manager: use apt-get/brew/pacman (see mapping table below)
+
+# --- Generate TCL modulefile ---
+MODFILE_DIR="${EDA_MODULEFILES_ROOT}/${TOOL_NAME}"
+mkdir -p "${MODFILE_DIR}"
+
+cat > "${MODFILE_DIR}/${TOOL_VERSION}" <<EOF
+#%Module1.0
+proc ModulesHelp { } {
+    puts stderr "<Tool Full Name> ${TOOL_VERSION}"
+}
+module-whatis "<Tool Full Name> ${TOOL_VERSION} — <one-line description>"
+
+set prefix ${INSTALL_DIR}
+prepend-path PATH            \$prefix/bin
+prepend-path LD_LIBRARY_PATH \$prefix/lib
+prepend-path MANPATH         \$prefix/share/man
+# add PYTHONPATH, PKG_CONFIG_PATH, or tool-specific setenv as needed
+EOF
+
+echo "Modulefile written: ${MODFILE_DIR}/${TOOL_VERSION}"
+
+# --- Register modulefiles root (if not already set) ---
+# export MODULEPATH=${EDA_MODULEFILES_ROOT}:${MODULEPATH}
+# Add the above line to ~/.bashrc or /etc/profile.d/eda-modules.sh
+```
+
+If `module_system == "none"`: emit WARN in stage output and omit the modulefile block from the install script entirely.
+
+**Modulefile content rules:**
+- Minimum env vars in every modulefile: `PATH`, `LD_LIBRARY_PATH`
+- Add where applicable: `MANPATH`, `PKG_CONFIG_PATH`, `PYTHONPATH`
+- Tool-specific root vars (set these when present):
+  - Verilator → `VERILATOR_ROOT`
+  - Yosys → `YOSYS_DATDIR`
+  - LLVM → `LLVM_DIR`
+  - cocotb → `COCOTB_SHARE_DIR`
+
+### Package Name Mapping Table
+
+| Tool command | apt package(s) | brew formula | pacman pkg | fallback / notes |
+|---|---|---|---|---|
+| `verilator` | `verilator` | `verilator` | `verilator` | — |
+| `slang` | build-from-source | — | — | https://github.com/MikePopoloski/slang |
+| `surelog` | build-from-source | — | — | https://github.com/chipsalliance/Surelog |
+| `sv2v` | build-from-source | — | — | https://github.com/zachjs/sv2v |
+| `iverilog` | `iverilog` | `icarus-verilog` | `iverilog` | — |
+| `yosys` | `yosys` | `yosys` | `yosys` | — |
+| `abc` | build-from-source | `berkeley-abc` | — | https://github.com/berkeley-abc/abc |
+| `openroad` | build-from-source | — | — | https://github.com/The-OpenROAD-Project/OpenROAD |
+| `openlane` | `<PYTHON_EXEC> -m pip install openlane` | `<PYTHON_EXEC> -m pip install openlane` | `<PYTHON_EXEC> -m pip install openlane` | Python package; substitute `<PYTHON_EXEC>` with `python_env.exec` from `tool-status.json` |
+| `klayout` | `klayout` | `klayout` | `klayout` (AUR) | — |
+| `sta` | build-from-source | — | — | https://github.com/The-OpenROAD-Project/OpenSTA |
+| `sby` | `symbiyosys` | — | — | https://github.com/YosysHQ/sby |
+| `gem5` | build-from-source | — | — | https://github.com/gem5/gem5 |
+| `bambu-hls` | vendor download (Linux only) | — | — | https://github.com/ferrandi/PandA-bambu; WARN on macOS/Windows |
+| `nextpnr` | `nextpnr-ice40 nextpnr-ecp5` | `nextpnr` | `nextpnr` | — |
+| `openFPGALoader` | `openfpgaloader` | — | — | https://github.com/trabucayre/openFPGALoader |
+| `cocotb` | `<PYTHON_EXEC> -m pip install cocotb` | `<PYTHON_EXEC> -m pip install cocotb` | `<PYTHON_EXEC> -m pip install cocotb` | Python package; use `<PYTHON_BIN_DIR>/cocotb-config` or `cocotb-config` to detect |
+| `llvm-config` | `llvm-dev` | `llvm` | `llvm` | — |
+| `gcc` | `build-essential` | `gcc` | `gcc` | — |
+| `openocd` | `openocd` | `open-ocd` | `openocd` | — |
+| `xschem` | `xschem` | build-from-source | — | https://github.com/StefanSchippers/xschem |
+| `gtkwave` | `gtkwave` | `gtkwave` | `gtkwave` | — |
+| `uv` | `curl -LsSf https://astral.sh/uv/install.sh \| sh` (standalone) or `<PYTHON_EXEC> -m pip install uv` | `uv` (brew) or `<PYTHON_EXEC> -m pip install uv` | `<PYTHON_EXEC> -m pip install uv` | Prefer standalone astral.sh installer; pip fallback when custom/module Python is active |
+
 ### Output Required
-- `install-missing-tools.sh` — executable install script for all MISSING tools
-- `tool-manifest.json` — final confirmed tool list after installation
+- One `install-<toolname>.sh` per MISSING tool written to `install-missing-tools/` (no single combined script)
 
 ---
 
@@ -260,20 +531,27 @@ Printed MCP config snippets for each tool with resolved absolute paths
 ## Stage: environment_validation
 
 ### Domain Rules
-1. Re-run tool presence checks against `tool-manifest.json`
-2. Verify all 8 wrapper scripts exist and have executable bit set
-3. Verify MCP snippet files are present in `plugins/infrastructure/mcp/`
-4. FAIL if any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) is still missing
-5. Print final sign-off summary: tools detected, wrappers deployed, MCP servers configured
+1. **Python environment check** — before any other check: read `python_env` from `tool-status.json`:
+   - If `python_env.type == "module"`: run `which python3` to verify the module is still loaded. If it fails, FAIL immediately with: `"Python environment not active — source load-modules.sh (module: <python_env.module_name>) and re-run environment_validation."`
+   - If `python_env.type == "custom"` or `"system"`: run `which python3` and verify the path matches `python_env.exec`; emit WARN if it differs.
+2. Re-run tool presence checks using the same Python-aware detection as `tool_discovery` rules 2–3: use `"$PYTHON_EXEC" -m pip show` for `openlane`, `"$PYTHON_BIN_DIR/cocotb-config"` for `cocotb`, `"$PYTHON_BIN_DIR/uv"` for `uv` — do not fall back to bare `which` for Python packages. Compare results against `tool-manifest.json`.
+3. Verify all 8 wrapper scripts exist and have executable bit set
+4. Verify MCP snippet files are present in `plugins/infrastructure/mcp/` (all 10 snippets) and that `mcp-adapter.py` + `mcp-session-adapter.py` are present in `plugins/infrastructure/tools/`
+5. FAIL if any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) is still `MISSING`
+6. For each tool with status `MISSING_LOAD_MODULE` in `tool-status.json`: emit a WARN issue with description `"<tool> not in PATH — available via module"` and fix `"source load-modules.sh, then re-run environment_validation"`
+7. If any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) has status `MISSING_LOAD_MODULE`: emit WARN and set `recommendation: "escalate"` with message `"Critical tool <tool> requires module load before downstream flows can run. Source load-modules.sh and re-run environment_validation."`
+8. Print final sign-off summary: tools detected, tools via modules, wrappers deployed, MCP servers configured
 
 ### Sign-off Checklist
-- [ ] `tool-status.json` written with all tools surveyed
-- [ ] `install-missing-tools.sh` generated (auto-run is user's choice)
+- [ ] `tool-status.json` written with all tools surveyed (includes `python_env` object)
+- [ ] `module-status.json` written (even if `module_system` is `"none"`)
+- [ ] `install-<toolname>.sh` scripts generated for all MISSING tools in `install-missing-tools/` (auto-run is user's choice)
+- [ ] `load-modules.sh` generated if any module-available tools found (auto-run is user's choice)
 - [ ] `tool-manifest.json` written
 - [ ] All 8 wrappers deployed and executable
 - [ ] `mcp-adapter.py` and `mcp-session-adapter.py` present in `plugins/infrastructure/tools/`
 - [ ] All 10 MCP config snippets written with resolved absolute paths and printed
-- [ ] No critical-path tools missing
+- [ ] No critical-path tools with status `MISSING` or `MISSING_LOAD_MODULE`
 
 ### Output Required
 - Printed environment validation report

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -261,7 +261,7 @@ Note: The top-level `python_env` object is **preserved unchanged** during this s
 
 ### Stage Output Summary
 Print a human-readable table before advancing:
-```
+```text
 Module system : Environment Modules 4.8.0 (TCL)
 Tools in PATH : 12
 Tools via modules : 5
@@ -320,7 +320,7 @@ module load cadence/xcelium/20.09
     ```
     Use `"$PYTHON_EXEC" -m pip install <package>` as the install command. Never use bare `pip install` when `python_env.type` is `"custom"` or `"module"`.
 7. Proprietary tools: no script generated — record a note in the sign-off summary only
-8. Modulefile format: always TCL classic (no file extension); if `module_system == "none"`, emit WARN and skip modulefile generation
+8. Modulefile format: always TCL classic (no file extension); always generate modulefiles unconditionally — if `module_system == "none"`, emit WARN that automatic module loading is unavailable but still output the modulefile
 9. Each script must end with guidance for registering `$EDA_MODULEFILES_ROOT` in `$MODULEPATH` if not already present
 10. Write all `install-<toolname>.sh` scripts to the `install-missing-tools/` directory; create the directory if it does not exist; do **not** create the directory or any scripts if no tools are `MISSING`
 
@@ -334,7 +334,7 @@ module load cadence/xcelium/20.09
 
 ### Install Directory Layout
 
-```
+```text
 $EDA_TOOLS_ROOT/                         (default: /tools)
   <toolname>/<version>/                  e.g. /tools/verilator/5.028/
     bin/
@@ -393,7 +393,7 @@ echo "Modulefile written: ${MODFILE_DIR}/${TOOL_VERSION}"
 # Add the above line to ~/.bashrc or /etc/profile.d/eda-modules.sh
 ```
 
-If `module_system == "none"`: emit WARN in stage output and omit the modulefile block from the install script entirely.
+If `module_system == "none"`: emit WARN in stage output that automatic module loading is unavailable, but still generate the modulefile block in the install script.
 
 **Modulefile content rules:**
 - Minimum env vars in every modulefile: `PATH`, `LD_LIBRARY_PATH`


### PR DESCRIPTION
## 📌 Description

- Introduces a new `module_discovery` stage between `tool_discovery` and `tool_installation` that probes TCL Environment Modules, maps available modules to EDA tools, and generates a `load-modules.sh` helper.
- Adds a Python interpreter detection step to `tool_discovery` that classifies the active Python as `system`, `custom`, or `module`, records it in `tool-status.json` under a new `python_env` object, and uses it to drive Python-package detection (`cocotb`, `openlane`, `uv`).
- Replaces the single `install-missing-tools.sh` with one `install-<toolname>.sh` per MISSING tool under `install-missing-tools/`, each producing a TCL modulefile at `$EDA_MODULEFILES_ROOT/<toolname>/<version>` and installing to `$EDA_TOOLS_ROOT/<toolname>/<version>`.
- Extends `tool-status.json` with `FOUND_PREFER_MODULE` / `MISSING_LOAD_MODULE` statuses plus `module_names` and `versions_available` fields; adds `module-status.json` output.
- Adds `xschem`, `GTKWave`, and `uv` to the open-source tool inventory and package mapping table.
- Expands `environment_validation` with a Python-env liveness check, module-aware re-detection, and new sign-off items for module status and per-tool install scripts.
- Updates loop-back rules and state schema in the orchestrator to cover the new stage, module system detection, and Python-module-not-loaded escalations.

## 🧪 Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Improvement / refactor
- [ ] Documentation update

## 🧠 What Changed?
- `plugins/infrastructure/agents/infrastructure-orchestrator.md`
- `plugins/infrastructure/skills/infrastructure/SKILL.md`


## 🔄 Affected Areas
- [X] Agent logic
- [ ] Workflow orchestration
- [ ] Scripts / tooling
- [ ] Documentation
- [ ] Other:

## ⚙️ How to Test
All items below have been executed locally and pass.

- [x] Run the infrastructure orchestrator on a host **with** TCL Environment Modules and at least one Python module; verify `module_discovery` detects it, `load-modules.sh` is generated, and `python_env.type == "module"`.
- [x] Run on a host **without** a module system; verify `module_discovery` emits WARN, skips `load-modules.sh`, and the flow advances cleanly to `tool_installation`.
- [x] Trigger a MISSING tool (e.g. remove `verilator` from PATH) and confirm `install-missing-tools/install-verilator.sh` is generated with a valid TCL modulefile block and correct `$EDA_TOOLS_ROOT` / `$EDA_MODULEFILES_ROOT` handling.
- [x] With a custom Python (virtualenv / pyenv), confirm `cocotb`, `openlane`, and `uv` detection uses `$PYTHON_BIN_DIR` first and `$PYTHON_EXEC -m pip install` in generated scripts.
- [x] Force a critical-path tool (Yosys/Verilator/OpenROAD/OpenSTA) into `MISSING_LOAD_MODULE` and verify `environment_validation` escalates with the documented message.
- [x] Confirm `tool-status.json` schema is backward-compatible: legacy consumers reading the `tools` array still parse; new consumers see `python_env` and module fields.

## ⚠️ Risks / Notes
Any known limitations, edge cases, or concerns

## ✅ Checklist
- [X] Changes are scoped and minimal
- [X] Verified functionality manually or via tests
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)

## 📎 Additional Context
Might (partially) address future work "Infrastructure Orchestrator Memory" by maintaining different tool versions with modulefiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Module-based discovery for Python interpreters and EDA tools via environment modules
  * Per-tool installation scripts with automatic TCL modulefile generation
  * Added support for xschem, gtkwave, and uv tools

* **Improvements**
  * Enhanced Python environment detection and validation
  * Improved error handling for missing tools and optional module systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->