### PR TITLE
[Review] Add pre-run context, run_state update, clock gating analysis and OpenROAD MCP update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [Unreleased] — agent-scope-review branch
+
+### Added
+- **Pre-run context** (`## Pre-run Context`) section added to all 13 domain SKILL.md files:
+  agents now read `knowledge.md` and `run_state.md` at every invocation point, not only
+  at orchestrator session start.
+- **Run-state tracking**: all 13 domain SKILL.md files and the PD orchestrator now write
+  `memory/<domain>/run_state.md` as the first action before any tool invocation; `last_stage`
+  is updated after each stage so wakeup-loop prompts can resume correctly.
+- **Per-stage experience writes**: PD orchestrator (and all domain skills) now upsert to
+  `experiences.jsonl` after each stage rather than only on session end; partial runs are
+  persisted even if the session is interrupted.
+- **Optional claude-mem integration**: all 13 domain skills and the memory-keeper skill now
+  emit applied fixes to `mcp__plugin_ecc_memory__add_observations` when the MCP tool is
+  present; guard clause skips silently when absent so JSONL remains the canonical record.
+- **Clock gating opportunity analysis** added to `architecture` SKILL.md
+  (`power_area_estimation` stage): classifies each clock domain by activity factor α,
+  produces a `clock_power_budget` hand-off table (domain → frequency, α, est. clock power,
+  gating class), and enforces a new QoR gate (≥ 70% of register bits in gateable domains).
+- **Power intent / ICG insertion rules** added to `rtl-design` SKILL.md (`rtl_coding` stage):
+  RTL agent reads `clock_power_budget` from architecture hand-off and inserts ICG cells for
+  high/moderate gating domains; enforces `clock_gating_coverage` ≥ 60% QoR gate.
+- **Architecture → RTL handoff contract** updated in `docs/MASTER_INDEX.md` to include
+  `clock_power_budget` artifact.
+- `memory/README.md` updated to document run_state.md, per-stage write semantics, `run_id`
+  schema field, and the optional claude-mem index pattern.
+- `docs/Architecture_Evaluation_Flow.md` and `docs/RTL_Design_Flow.md` updated to match
+  the new clock gating analysis and ICG insertion rules added to the live SKILL.md files.
+- OpenROAD MCP config (`mcp-openroad.json`) comment improved to call out the two placeholder
+  values that require substitution during installation.
+
+---
+
 ## [1.2.0] — 2026-04-14
 
 ### Added

--- a/docs/Architecture_Evaluation_Flow.md
+++ b/docs/Architecture_Evaluation_Flow.md
@@ -234,7 +234,7 @@ Using activity factors already collected for dynamic power:
 - Area estimate: < 80% of budget (to allow RTL overhead margin)
 - Dynamic power: < 80% of budget
 - Leakage power: < 15% of total estimated power
-- Clock gating coverage: ≥ 70% of register-bank bits in high/moderate gating domains
+- Clock-gating coverage: ≥ 60% of register-bank bits in high-opportunity domains
 - Confidence level: HIGH / MEDIUM / LOW (based on model fidelity)
 
 ## Output Required
@@ -297,7 +297,7 @@ requirements and is ready to proceed to RTL design.
 - [ ] DFT strategy agreed (scan, BIST, JTAG)
 - [ ] Verification strategy agreed (UVM, formal, emulation split)
 - [ ] `clock_power_budget` table produced; gating class assigned per domain
-- [ ] Clock gating coverage ≥ 70% of register bits (high + moderate gating domains)
+- [ ] Clock-gating coverage ≥ 60% of register bits in high-opportunity domains
 - [ ] Hand-off package includes `clock_power_budget` table for RTL team
 
 ## Output Required

--- a/docs/Architecture_Evaluation_Flow.md
+++ b/docs/Architecture_Evaluation_Flow.md
@@ -213,16 +213,35 @@ microarchitecture before RTL is written.
 6. Apply 15–20% margin to all estimates (RTL is never minimal)
 7. Compare against budget; flag if estimate exceeds 80% of budget
 
+## Clock Gating Opportunity Analysis
+Using activity factors already collected for dynamic power:
+
+1. For each clock domain, record activity factor α from use-case workload sweep.
+2. Classify each domain:
+   - α < 0.15 — **high gating opportunity**: flag as must-have RTL requirement
+   - 0.15 ≤ α < 0.40 — **moderate gating opportunity**: flag as should-have RTL requirement
+   - α ≥ 0.40 — **always-active**: document as always-on; no ICG needed
+3. Produce a `clock_power_budget` table (one row per domain):
+
+   | Domain | Frequency | α (activity) | Est. Clock Power (mW) | Gating Class |
+   |--------|-----------|-------------|----------------------|--------------|
+   | core   | 1 GHz     | 0.08        | 45                   | high         |
+   | dsp    | 500 MHz   | 0.55        | 30                   | always-on    |
+
+4. Include `clock_power_budget` table in the RTL hand-off package.
+
 ## QoR Metrics
 - Area estimate: < 80% of budget (to allow RTL overhead margin)
 - Dynamic power: < 80% of budget
 - Leakage power: < 15% of total estimated power
+- Clock gating coverage: ≥ 70% of register-bank bits in high/moderate gating domains
 - Confidence level: HIGH / MEDIUM / LOW (based on model fidelity)
 
 ## Output Required
 - Area breakdown by block
 - Power breakdown: dynamic, leakage, per domain
 - Comparison against targets with margin analysis
+- `clock_power_budget` table (domain → frequency, activity factor, estimated clock power, gating class)
 ```
 
 ---
@@ -277,12 +296,15 @@ requirements and is ready to proceed to RTL design.
 - [ ] Reset strategy defined
 - [ ] DFT strategy agreed (scan, BIST, JTAG)
 - [ ] Verification strategy agreed (UVM, formal, emulation split)
+- [ ] `clock_power_budget` table produced; gating class assigned per domain
+- [ ] Clock gating coverage ≥ 70% of register bits (high + moderate gating domains)
+- [ ] Hand-off package includes `clock_power_budget` table for RTL team
 
 ## Output Required
 - Signed-off microarchitecture document
 - Final trade-off decision record
 - RTL design guidelines derived from architecture
-- Hand-off package for RTL team
+- Hand-off package for RTL team (includes `clock_power_budget` table)
 ```
 
 ---

--- a/docs/MASTER_INDEX.md
+++ b/docs/MASTER_INDEX.md
@@ -101,13 +101,14 @@ Each orchestrator produces a standardized handoff package consumed by the next.
   "from": "Architecture Evaluation Orchestrator",
   "to":   "RTL Design Orchestrator",
   "package": {
-    "microarch_doc":    "path/to/microarch.md",
-    "module_hierarchy": "path/to/hierarchy.json",
-    "interface_specs":  "path/to/interfaces.md",
-    "memory_map":       "path/to/memory_map.md",
-    "clock_domains":    ["clk_core_1GHz", "clk_peri_200MHz"],
-    "coding_guidelines":"path/to/guidelines.md",
-    "verification_plan":"path/to/vplan.md"
+    "microarch_doc":       "path/to/microarch.md",
+    "module_hierarchy":    "path/to/hierarchy.json",
+    "interface_specs":     "path/to/interfaces.md",
+    "memory_map":          "path/to/memory_map.md",
+    "clock_domains":       ["clk_core_1GHz", "clk_peri_200MHz"],
+    "clock_power_budget":  "path/to/clock_power_budget.md",
+    "coding_guidelines":   "path/to/guidelines.md",
+    "verification_plan":   "path/to/vplan.md"
   }
 }
 ```

--- a/docs/RTL_Design_Flow.md
+++ b/docs/RTL_Design_Flow.md
@@ -182,10 +182,28 @@ Enforce synthesizable, readable, and maintainable RTL coding practices.
 3. Use gray-coded counters for pointer crossings in async FIFOs
 4. Never sample asynchronous data directly in synchronous logic
 
+## Domain Rules — Power Intent (Clock Gating)
+Read `clock_power_budget` from architecture hand-off if it exists; else use
+Verilator toggle coverage to estimate activity factors.
+
+1. **High gating opportunity** (α < 0.15): insert ICG cell (`CLKGATETST_X*` or
+   technology equivalent) at the outermost clock enable boundary. Explicit ICG
+   insertion at RTL is required — do not rely on synthesis inference.
+2. **Moderate gating opportunity** (0.15 ≤ α < 0.40): insert ICG at sub-block
+   level for any register file or datapath wider than 32 bits.
+3. **Always-on** (α ≥ 0.40 or documented as always-on): no ICG required; add a
+   `/* always-on: <reason> */` comment at the clock port declaration.
+4. ICG enable signal must be registered (combinational enable is a lint error).
+5. Use only library-approved cells (`CLKGATETST_*`); no behavioral clock gating.
+6. Measure `clock_gating_coverage`:
+   `coverage = (register bits behind ICG / total register bits in domain) × 100%`
+   QoR gate: ≥ 60% for high-opportunity domains; report in sign-off record.
+
 ## Output Required
 - RTL source files (.sv) per module
 - Self-checking assertions (SVA) per module
 - Inline comments explaining non-obvious logic
+- `clock_gating_coverage` metric per domain (appended to sign-off record)
 ```
 
 ---
@@ -323,6 +341,9 @@ and synthesis handoff.
 - [ ] SVA assertions in place for key properties
 - [ ] Code review completed
 - [ ] File list and compile order documented
+- [ ] ICG cells inserted for all high/moderate gating opportunity domains
+- [ ] Always-on domains annotated with `/* always-on: <reason> */`
+- [ ] `clock_gating_coverage` ≥ 60% for high-opportunity domains; reported in sign-off record
 
 ## Output Required
 - RTL file package (all .sv files)

--- a/memory/README.md
+++ b/memory/README.md
@@ -7,8 +7,8 @@ an experience record after each stage completes — no new infrastructure requir
 ## Two-Tier Design
 
 ### Tier 1 — `experiences.jsonl`
-Append-only JSONL file. One record per completed (or abandoned) orchestrator run.
-Machine-parseable; grows over time; never edited manually.
+JSONL file with per-stage upsert/overwrite by run_id. One record per orchestrator run,
+updated as stages complete. Machine-parseable; grows over time; never edited manually.
 
 ### Tier 2 — `knowledge.md`
 Human- and agent-readable distilled summary. Seeded with known failure patterns, successful

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,7 +1,8 @@
 # Agent Memory System
 
 This directory holds persistent, file-based memory for the digital chip design orchestrators.
-Agents read it at session start and write to it at session end — no new infrastructure required.
+Agents read it at session start, write a run-state file before the first stage, and upsert
+an experience record after each stage completes — no new infrastructure required.
 
 ## Two-Tier Design
 
@@ -18,6 +19,7 @@ tool flags, and PDK/tool quirks. Intended to be periodically updated by a memory
 
 ```json
 {
+  "run_id": "<domain>_<YYYYMMDD>_<HHMMSS>",
   "timestamp": "<ISO-8601>",
   "domain": "<domain>",
   "design_name": "<from state>",
@@ -60,7 +62,8 @@ memory/
 │   └── .gitkeep
 ├── architecture/
 │   ├── knowledge.md             ← Tier 2: seeded domain knowledge
-│   └── experiences.jsonl        ← Tier 1: created on first run
+│   ├── experiences.jsonl        ← Tier 1: created on first run
+│   └── run_state.md             ← active run identity (created at session start)
 ├── compiler/
 ├── dft/
 ├── firmware/
@@ -77,10 +80,19 @@ memory/
 
 ## How Orchestrators Use This
 
-**Session start**: Read `memory/<domain>/knowledge.md` before the first stage.
-Incorporate guidance into stage decisions — especially known failure patterns,
-successful tool flags, and PDK-specific notes.
+**Session start**: Read `memory/<domain>/knowledge.md` and `memory/<domain>/run_state.md`
+before the first stage. `knowledge.md` provides known failure patterns and tool flags.
+`run_state.md` (if present) identifies an interrupted run to resume.
 
-**Session end**: After signoff (or on escalation/abandon), append one JSON line to
-`memory/<domain>/experiences.jsonl`. Create the file and parent directories if they
-do not exist.
+**Before first stage**: Write `memory/<domain>/run_state.md` with `run_id`, `design_name`,
+`tool`, `start_time`, and `last_stage`. Update `last_stage` after each stage completes.
+
+**Per stage**: Upsert (create-or-replace by `run_id`) one JSON line in
+`memory/<domain>/experiences.jsonl` with `signoff_achieved: false` and the metrics
+available so far. On final sign-off, set `signoff_achieved: true`. Do not append a second
+line for the same `run_id` — overwrite the existing line.
+
+**Optional — claude-mem index**: If `mcp__plugin_ecc_memory__add_observations` is available
+in the session, also emit each applied fix as an observation to entity
+`chip-design-<domain>-fixes`. Skip silently if the tool is absent — JSONL is the canonical
+record; claude-mem is a supplemental cross-session search index only.

--- a/plugins/architecture/skills/architecture/SKILL.md
+++ b/plugins/architecture/skills/architecture/SKILL.md
@@ -194,8 +194,10 @@ Perform this analysis using the activity factors already collected for dynamic p
 - Area estimate: < 80% of budget
 - Dynamic power: < 80% of budget
 - Leakage: < 15% of total estimated power
-- Clock gating coverage: ≥ 70% of register-bank bits must map to a domain classified
-  as high or moderate gating opportunity (i.e. not always-on)
+- Clock-gating coverage: ≥ 60% of register-bank bits in high-opportunity domains
+  (measured using planned register-map estimates from the microarchitecture specification;
+  mark estimate confidence as HIGH if register counts are frozen, MEDIUM if approximate,
+  LOW if based on scaling from similar designs)
 - Confidence: HIGH / MEDIUM / LOW
 
 ### Output Required
@@ -244,7 +246,7 @@ Perform this analysis using the activity factors already collected for dynamic p
 - [ ] Verification strategy agreed
 - [ ] RTL coding guidelines documented
 - [ ] `clock_power_budget` table produced; gating class assigned per domain
-- [ ] Clock gating coverage ≥ 70% of register bits (high + moderate gating domains)
+- [ ] Clock-gating coverage ≥ 60% of register bits in high-opportunity domains
 - [ ] Hand-off package complete for RTL team (includes `clock_power_budget` table)
 
 ### Output Required

--- a/plugins/architecture/skills/architecture/SKILL.md
+++ b/plugins/architecture/skills/architecture/SKILL.md
@@ -274,9 +274,9 @@ run_id:      architecture_<YYYYMMDD>_<HHMMSS>
 design_name: <design>
 tool:        <primary tool>
 start_time:  <ISO-8601>
-last_stage:  <first stage name>
+last_stage:  null
 ```
-Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+Update `last_stage` to the completed stage name only after each stage finishes successfully. This file lets wakeup-loop prompts
 and resumed sessions identify the correct run without relying on in-memory state.
 Create the file and parent directories if they do not exist.
 

--- a/plugins/architecture/skills/architecture/SKILL.md
+++ b/plugins/architecture/skills/architecture/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/architecture/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/architecture/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide the full microarchitecture evaluation process from product specification
 through to a signed-off microarchitecture document ready for RTL handoff. Covers
@@ -144,16 +157,52 @@ PPA modelling, risk assessment, and sign-off.
 6. Apply 15–20% margin — RTL is never minimal
 7. Flag immediately if any estimate exceeds 80% of budget
 
+### Clock Gating Opportunity Analysis
+Perform this analysis using the activity factors already collected for dynamic power:
+
+1. For each identified clock domain, record its activity factor α derived from the
+   use-case workload sweep (gem5 simulation or analytical model).
+2. Classify each domain:
+   - α < 0.15 — **high gating opportunity**: clock gating will save > 30% dynamic power
+     for that domain; flag as a must-have RTL requirement.
+   - 0.15 ≤ α < 0.40 — **moderate gating opportunity**: clock gating recommended;
+     flag as should-have RTL requirement.
+   - α ≥ 0.40 — **always-active**: no gating benefit; document as always-on.
+3. Produce a `clock_power_budget` table (one row per domain):
+
+   | Domain | Frequency | α (activity) | Est. Clock Power (mW) | Gating Class |
+   |--------|-----------|-------------|----------------------|--------------|
+   | core   | 1 GHz     | 0.08        | 45                   | high         |
+   | dsp    | 500 MHz   | 0.55        | 30                   | always-on    |
+
+4. McPAT `clocking` component already models clock network power — ensure the
+   frequency-sweep input reflects per-domain frequencies, not a single global clock.
+5. Include the `clock_power_budget` table in the hand-off package to RTL design.
+   The RTL agent will use it to target ICG (Integrated Clock Gate) insertion.
+
+### Supported Tools for Clock/Power Analysis
+| Tool | Type | Use |
+|------|------|-----|
+| McPAT | Open-source | Clock network + dynamic/leakage power (already in flow) |
+| gem5 | Open-source | Workload activity factor extraction (already in flow) |
+| CACTI | Open-source | Memory clock power estimate (already in flow) |
+| Yosys + ABC | Open-source | Post-synth switching activity cross-check (optional) |
+| Synopsys PrimePower | Proprietary | RTL-level power sign-off (optional) |
+| Cadence Joules RTL | Proprietary | RTL power analysis (optional) |
+
 ### QoR Metrics to Evaluate
 - Area estimate: < 80% of budget
 - Dynamic power: < 80% of budget
 - Leakage: < 15% of total estimated power
+- Clock gating coverage: ≥ 70% of register-bank bits must map to a domain classified
+  as high or moderate gating opportunity (i.e. not always-on)
 - Confidence: HIGH / MEDIUM / LOW
 
 ### Output Required
 - Area breakdown by block
 - Power breakdown: dynamic, leakage, per domain
 - Margin analysis vs targets
+- `clock_power_budget` table (domain → frequency, activity factor, estimated clock power mW, gating class)
 
 ---
 
@@ -194,7 +243,9 @@ PPA modelling, risk assessment, and sign-off.
 - [ ] DFT strategy agreed
 - [ ] Verification strategy agreed
 - [ ] RTL coding guidelines documented
-- [ ] Hand-off package complete for RTL team
+- [ ] `clock_power_budget` table produced; gating class assigned per domain
+- [ ] Clock gating coverage ≥ 70% of register bits (high + moderate gating domains)
+- [ ] Hand-off package complete for RTL team (includes `clock_power_budget` table)
 
 ### Output Required
 - Signed-off microarchitecture document
@@ -214,3 +265,20 @@ without full orchestrator context.
 
 Use `run_id` = `architecture_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/architecture/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      architecture_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-architecture-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/compiler/skills/compiler-toolchain/SKILL.md
+++ b/plugins/compiler/skills/compiler-toolchain/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/compiler/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/compiler/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Build and validate a complete compiler toolchain (LLVM or GCC based) for a
 custom processor ISA. Bridges hardware and software — without a working
@@ -264,3 +277,20 @@ Use `run_id` = `compiler_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on 
 stage update). Every JSON record written must include a top-level `"run_id"` field
 whose value matches this key — this is what makes overwrites unambiguous. Set
 `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/compiler/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      compiler_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-compiler-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/dft/skills/dft/SKILL.md
+++ b/plugins/dft/skills/dft/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/dft/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/dft/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide the complete DFT flow from architecture planning through ATPG pattern
 generation, BIST insertion, JTAG setup, and sign-off. Ensures the manufactured
@@ -219,3 +232,20 @@ Use `run_id` = `dft_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Every JSON record written must include a top-level `"run_id"` field
 whose value matches this key — reject or regenerate if missing before writing. Set
 `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/dft/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      dft_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-dft-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/dft/skills/dft/SKILL.md
+++ b/plugins/dft/skills/dft/SKILL.md
@@ -239,11 +239,11 @@ run_id:      dft_<YYYYMMDD>_<HHMMSS>
 design_name: <design>
 tool:        <primary tool>
 start_time:  <ISO-8601>
-last_stage:  <first stage name>
+last_stage:  null
 ```
-Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
-and resumed sessions identify the correct run without relying on in-memory state.
-Create the file and parent directories if they do not exist.
+Update `last_stage` to the completed stage name only after each stage finishes successfully.
+This file lets wakeup-loop prompts and resumed sessions identify the correct run without
+relying on in-memory state. Create the file and parent directories if they do not exist.
 
 ### Optional: claude-mem index
 If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each

--- a/plugins/firmware/skills/embedded-firmware/SKILL.md
+++ b/plugins/firmware/skills/embedded-firmware/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/firmware/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/firmware/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide BSP creation, peripheral driver development, RTOS integration, and
 system-level firmware validation. The firmware layer is the first software
@@ -233,3 +246,20 @@ without full orchestrator context.
 
 Use `run_id` = `firmware_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/firmware/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      firmware_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-firmware-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/formal/skills/formal-verification/SKILL.md
+++ b/plugins/formal/skills/formal-verification/SKILL.md
@@ -235,15 +235,17 @@ completes.
 ### Run state (write before first stage, update after each stage)
 Write `memory/formal/run_state.md` as the **first action** before launching any tool:
 ```markdown
-run_id:      formal_<YYYYMMDD>_<HHMMSS>
-design_name: <design>
-tool:        <primary tool>
-start_time:  <ISO-8601>
-last_stage:  <first stage name>
+run_id:       formal_<YYYYMMDD>_<HHMMSS>
+design_name:  <design>
+tool:         <primary tool>
+start_time:   <ISO-8601>
+last_stage:   null
+current_stage: <first stage name>
 ```
-Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
-and resumed sessions identify the correct run without relying on in-memory state.
-Create the file and parent directories if they do not exist.
+Update `current_stage` when a stage starts, and set `last_stage` to the completed stage
+name only after successful completion (then clear `current_stage`). This file lets
+wakeup-loop prompts and resumed sessions identify the correct run and distinguish
+completed vs in-flight work. Create the file and parent directories if they do not exist.
 
 ### Optional: claude-mem index
 If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each

--- a/plugins/formal/skills/formal-verification/SKILL.md
+++ b/plugins/formal/skills/formal-verification/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/formal/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/formal/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Exhaustively prove design properties and equivalence using formal methods.
 Complements simulation-based verification for correctness proofs, protocol
@@ -219,3 +232,20 @@ stage update). Every JSON record written must include a top-level `"run_id"` fie
 whose value matches this key — stage writes must upsert/overwrite by matching this
 persisted `run_id`. Set `signoff_achieved: false` until the final sign-off stage
 completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/formal/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      formal_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-formal-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/fpga/skills/fpga-emulation/SKILL.md
+++ b/plugins/fpga/skills/fpga-emulation/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/fpga/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/fpga/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Port an ASIC design to an FPGA prototype platform for pre-silicon hardware/
 software co-development. The FPGA prototype is not cycle-accurate but
@@ -262,3 +275,20 @@ Field types: `run_id` and `stage` are non-empty strings; `timestamp` is ISO-8601
 `signoff_achieved` is a boolean (`false` for all stage appends; `true` only in the final
 sign-off append for the matching `run_id`); `outcomes` and `metrics` are objects; `tools`
 is an array of objects; `notes` is an optional string.
+### Run state (write before first stage, update after each stage)
+Write `memory/fpga/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      fpga_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-fpga-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/fpga/skills/fpga-emulation/SKILL.md
+++ b/plugins/fpga/skills/fpga-emulation/SKILL.md
@@ -278,15 +278,17 @@ is an array of objects; `notes` is an optional string.
 ### Run state (write before first stage, update after each stage)
 Write `memory/fpga/run_state.md` as the **first action** before launching any tool:
 ```markdown
-run_id:      fpga_<YYYYMMDD>_<HHMMSS>
-design_name: <design>
-tool:        <primary tool>
-start_time:  <ISO-8601>
-last_stage:  <first stage name>
+run_id:        fpga_<YYYYMMDD>_<HHMMSS>_<6-char-random>
+design_name:   <design>
+tool:          <primary tool>
+start_time:    <ISO-8601>
+last_stage:    null
+current_stage: <first stage name>
 ```
-Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
-and resumed sessions identify the correct run without relying on in-memory state.
-Create the file and parent directories if they do not exist.
+The 6-character random suffix must be lowercase hexadecimal [0-9a-f]. Update `current_stage`
+when a stage starts, and set `last_stage` to the completed stage name only after successful
+completion (then clear `current_stage`). This file lets wakeup-loop prompts and resumed
+sessions identify the correct run. Create the file and parent directories if they do not exist.
 
 ### Optional: claude-mem index
 If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each

--- a/plugins/hls/skills/hls/SKILL.md
+++ b/plugins/hls/skills/hls/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/hls/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/hls/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Convert C/C++/SystemC algorithmic descriptions to synthesisable RTL.
 Covers algorithm analysis for HLS compatibility, pragma/directive optimisation,
@@ -224,3 +237,20 @@ Use `run_id` = `hls_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Every JSON record written must include a top-level `"run_id"` field
 whose value matches this key — this is what makes overwrites unambiguous. Set
 `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/hls/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      hls_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-hls-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/infrastructure/mcp/mcp-openroad.json
+++ b/plugins/infrastructure/mcp/mcp-openroad.json
@@ -1,5 +1,12 @@
 {
-  "_comment": "OpenROAD batch MCP server — for single-stage invocations. For ECO iteration queries on a loaded design use mcp-openroad-session.json instead. Replace /absolute/path/to with the actual repo root path.",
+  "_comment": "OpenROAD batch MCP server — for single-stage invocations. For ECO iteration queries on a loaded design use mcp-openroad-session.json instead.",
+  "_setup": [
+    "Two substitutions required before use:",
+    "1. Replace the two '/absolute/path/to' strings in 'args' with the absolute path to this repo root (e.g. /home/user/digital-chip-design-agents).",
+    "2. Set PDK_ROOT in 'env' to the directory containing your installed PDKs (e.g. /home/user/pdk or $PDKPATH).",
+    "PLATFORM and TOOL_TIMEOUT_S can be left as-is or overridden per design.",
+    "Run 'bash install.sh' first — it copies this template and can apply path substitution automatically."
+  ],
   "mcpServers": {
     "openroad": {
       "type": "stdio",

--- a/plugins/infrastructure/skills/memory-keeper/SKILL.md
+++ b/plugins/infrastructure/skills/memory-keeper/SKILL.md
@@ -145,6 +145,13 @@ Structured summary object (in-memory) passed to `distil_knowledge`:
 - Console summary: how many new entries were added per section, and how many existing
   entries were annotated or corrected
 
+### Optional: claude-mem index
+After writing `knowledge.md`, if `mcp__plugin_ecc_memory__add_observations` is available
+in this session, emit each new issue/fix pair as an observation to entity
+`chip-design-<domain>-fixes`. Skip this step silently if the tool is absent — `knowledge.md`
+and `experiences.jsonl` are the canonical records. Do not hard-depend on claude-mem
+availability.
+
 ---
 
 ## Stage: report

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -70,14 +70,28 @@ placed/routed, prefer:
 ## Memory
 
 ### Read (session start)
-Before beginning `floorplan`, read `memory/pd/knowledge.md` if it exists.
-Incorporate its guidance into stage decisions — especially known failure patterns,
-successful tool flags, and PDK-specific notes. If the file does not exist, proceed
-without it.
+Before beginning `floorplan`, read the following if they exist:
+- `memory/pd/knowledge.md` — known failure patterns, tool flags, PDK quirks.
+  Incorporate into all stage decisions. If absent, proceed without it.
+- `memory/pd/run_state.md` — if present, a prior run was interrupted; use the
+  `run_id` and `last_stage` fields to resume correctly.
 
-### Write (session end)
-After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
-`memory/pd/experiences.jsonl`:
+### Write: run state (first action, before any tool invocation)
+Write `memory/pd/run_state.md`:
+```markdown
+run_id:      pd_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+pdk:         <pdk or unknown>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  floorplan
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+identify the correct run directory without depending on in-memory state.
+
+### Write: per-stage (after each stage)
+After every stage completes, upsert (create or replace by `run_id`) one JSON line in
+`memory/pd/experiences.jsonl` with the stages completed so far:
 ```json
 {
   "run_id": "<from state>",
@@ -96,9 +110,15 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
   },
   "issues_encountered": ["<description>", "..."],
   "fixes_applied": ["<description>", "..."],
-  "signoff_achieved": true,
+  "signoff_achieved": false,
   "notes": "<free-text observations>"
 }
 ```
-If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
+Set `signoff_achieved: true` only when the signoff stage passes all criteria.
+Do not append a second line for the same `run_id` — overwrite the existing line.
 Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index (per stage, if tool available)
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-pd-fixes` immediately after writing
+to `experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/pd/skills/physical-design/SKILL.md
+++ b/plugins/pd/skills/physical-design/SKILL.md
@@ -321,7 +321,12 @@ append a second line for the same run. Write with the stages completed so far an
 `signoff_achieved: false`; overwrite to `true` only when signoff passes.
 
 Use `run_id` = `pd_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Create the file and parent directories if they do not exist.
+stage update). **Every JSON record written to experiences.jsonl must include a top-level
+"run_id" field** (string) inside the record itself — upsert behavior is keyed by this field.
+Do not rely on external metadata; the "run_id" property must be present in the JSON object.
+Records should be written with stages completed and `signoff_achieved: false`, and only
+overwritten to `true` when signoff passes. Create the file and parent directories if they
+do not exist.
 
 ### Optional: claude-mem index
 If `mcp__plugin_ecc_memory__add_observations` is available in this session, also emit

--- a/plugins/pd/skills/physical-design/SKILL.md
+++ b/plugins/pd/skills/physical-design/SKILL.md
@@ -309,9 +309,9 @@ design_name: <design>
 pdk:         <pdk or unknown>
 tool:        <primary tool>
 start_time:  <ISO-8601>
-last_stage:  <stage name>
+last_stage:  null
 ```
-Update `last_stage` after each stage completes. This file allows wakeup-loop prompts
+Update `last_stage` to the completed stage name only after each stage finishes successfully. This file allows wakeup-loop prompts
 and resumed sessions to identify the correct run directory without relying on in-memory state.
 
 ### Write on stage completion

--- a/plugins/pd/skills/physical-design/SKILL.md
+++ b/plugins/pd/skills/physical-design/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/pd/knowledge.md` — known failure patterns, successful tool flags, PDK quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/pd/run_state.md` — current run identity (`run_id`, `design_name`, `pdk`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide the complete physical implementation flow from gate-level netlist to
 tape-out-ready GDS-II. Eight stages with explicit QoR gates and loop-back
@@ -288,11 +301,30 @@ Resume from step: `openlane --from <step_name> <config.json>`
 
 ## Memory
 
+### Run state (write before first stage, update after each stage)
+Write `memory/pd/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      pd_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+pdk:         <pdk or unknown>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <stage name>
+```
+Update `last_stage` after each stage completes. This file allows wakeup-loop prompts
+and resumed sessions to identify the correct run directory without relying on in-memory state.
+
 ### Write on stage completion
 After each stage completes (regardless of whether an orchestrator session is active),
-write or overwrite one JSON record in `memory/pd/experiences.jsonl` keyed by
-`run_id`. This ensures data is persisted even if the flow is interrupted or called
-without full orchestrator context.
+upsert one JSON record in `memory/pd/experiences.jsonl` keyed by `run_id` — do not
+append a second line for the same run. Write with the stages completed so far and
+`signoff_achieved: false`; overwrite to `true` only when signoff passes.
 
 Use `run_id` = `pd_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
-stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+stage update). Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, also emit
+each new fix as an observation to entity `chip-design-pd-fixes` after writing to
+`experiences.jsonl`. Skip this step silently if the tool is absent — the JSONL file
+is the canonical record.

--- a/plugins/rtl-design/skills/rtl-design/SKILL.md
+++ b/plugins/rtl-design/skills/rtl-design/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/rtl-design/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/rtl-design/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide RTL development from module hierarchy planning through lint-clean,
 CDC-clean, synthesis-ready RTL. Enforces industry-standard SystemVerilog
@@ -103,10 +116,40 @@ and synthesis handoff.
 3. Gray-coded pointers for async FIFO crossing
 4. Never sample asynchronous data directly in synchronous logic
 
+### Domain Rules — Power Intent (Clock Gating)
+Apply these rules for every clock domain. Read `clock_power_budget` from the architecture
+hand-off package if it exists; otherwise classify domains using toggle-count estimates
+from Verilator simulation.
+
+1. **High gating opportunity domains** (α < 0.15 from architecture, or toggle rate < 15%
+   from Verilator): insert an ICG cell (`CLKGATETST_X*` or technology-equivalent) at the
+   outermost clock enable boundary. Do not rely on synthesis to infer clock gates — explicit
+   ICG insertion at RTL is required.
+2. **Moderate gating opportunity domains** (0.15 ≤ α < 0.40): insert ICG at the
+   sub-block level for any register file or datapath wider than 32 bits.
+3. **Always-on domains** (α ≥ 0.40, or documented as always-on in architecture hand-off):
+   no ICG required; add a `/* always-on: <reason> */` comment at the clock port declaration.
+4. ICG enable signal: must be registered (setup-timing safe); combinational enable
+   is a lint error.
+5. ICG cells: use only library-approved cells (`CLKGATETST_*` for testability with
+   scan-enable override); do not use behavioural `if (enable) clk_gated = clk` constructs.
+6. After inserting ICGs, measure `clock_gating_coverage`:
+   `coverage = (register bits behind an ICG) / (total register bits in domain) × 100%`
+   Report this metric in the `rtl_signoff` output.
+
+### Supported Tools for Power Intent
+| Tool | Type | Use |
+|------|------|-----|
+| Verilator | Open-source | Toggle coverage → activity factor for gating classification |
+| SpyGlass (Synopsys) | Proprietary | RTL power lint, missing ICG detection |
+| VC Static (Synopsys) | Proprietary | Power-intent rule checking |
+| Questa PowerPro (Siemens) | Proprietary | Formal power analysis |
+
 ### Output Required
 - RTL source files (.sv) per module
 - SVA assertion files per module
 - Inline comments on all non-obvious logic
+- `clock_gating_coverage` metric per domain (appended to sign-off record)
 
 ---
 
@@ -196,6 +239,9 @@ and synthesis handoff.
 - [ ] SVA assertions in place for key properties
 - [ ] Code review completed
 - [ ] File list and compile order documented
+- [ ] ICG cells inserted for all high/moderate gating opportunity domains
+- [ ] Always-on domains annotated with `/* always-on: <reason> */`
+- [ ] `clock_gating_coverage` ≥ 60% for high-opportunity domains; reported in sign-off record
 
 ### Output Required
 - RTL file package (all .sv files)
@@ -216,3 +262,20 @@ without full orchestrator context.
 
 Use `run_id` = `rtl-design_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/rtl-design/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      rtl-design_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-rtl-design-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/rtl-design/skills/rtl-design/SKILL.md
+++ b/plugins/rtl-design/skills/rtl-design/SKILL.md
@@ -273,9 +273,9 @@ run_id:      rtl-design_<YYYYMMDD>_<HHMMSS>
 design_name: <design>
 tool:        <primary tool>
 start_time:  <ISO-8601>
-last_stage:  <first stage name>
+last_stage:  null
 ```
-Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+Update `last_stage` to the completed stage name only after each stage finishes successfully. This file lets wakeup-loop prompts
 and resumed sessions identify the correct run without relying on in-memory state.
 Create the file and parent directories if they do not exist.
 

--- a/plugins/rtl-design/skills/rtl-design/SKILL.md
+++ b/plugins/rtl-design/skills/rtl-design/SKILL.md
@@ -118,8 +118,11 @@ and synthesis handoff.
 
 ### Domain Rules — Power Intent (Clock Gating)
 Apply these rules for every clock domain. Read `clock_power_budget` from the architecture
-hand-off package if it exists; otherwise classify domains using toggle-count estimates
-from Verilator simulation.
+hand-off package. **For orchestrated Architecture → RTL runs, the `clock_power_budget` table
+is a required handoff contract; if missing, treat as a handoff violation and abort with a
+clear error directing the user to notify upstream packaging.** For non-orchestrated or local
+RTL-only runs, classify domains using toggle-count estimates from Verilator simulation as
+a fallback.
 
 1. **High gating opportunity domains** (α < 0.15 from architecture, or toggle rate < 15%
    from Verilator): insert an ICG cell (`CLKGATETST_X*` or technology-equivalent) at the
@@ -138,6 +141,7 @@ from Verilator simulation.
    Report this metric in the `rtl_signoff` output.
 
 ### Supported Tools for Power Intent
+
 | Tool | Type | Use |
 |------|------|-----|
 | Verilator | Open-source | Toggle coverage → activity factor for gating classification |

--- a/plugins/soc/skills/soc-integration/SKILL.md
+++ b/plugins/soc/skills/soc-integration/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/soc/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/soc/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Assemble a complete SoC from first-party RTL, licensed hard/soft IPs, and
 memory macros. Covers IP procurement, bus fabric configuration, top-level
@@ -220,3 +233,20 @@ without full orchestrator context.
 
 Use `run_id` = `soc_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/soc/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      soc_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-soc-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/sta/skills/sta/SKILL.md
+++ b/plugins/sta/skills/sta/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/sta/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/sta/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Multi-corner, multi-mode timing analysis, exception review, ECO-guided closure,
 and timing sign-off. WNS ≥ 0 and TNS = 0 at all corners required for tape-out.
@@ -245,3 +258,20 @@ without full orchestrator context.
 
 Use `run_id` = `sta_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/sta/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      sta_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-sta-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/synthesis/skills/logic-synthesis/SKILL.md
+++ b/plugins/synthesis/skills/logic-synthesis/SKILL.md
@@ -25,6 +25,19 @@ allowed-tools: Read, Write, Bash
 Spawning the orchestrator from within an active orchestrator run causes recursive
 delegation and must never happen.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/synthesis/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/synthesis/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Produce a timing-clean, area-efficient, LEC-verified gate-level netlist
 from RTL. Covers constraint setup, synthesis compilation strategy, and
@@ -204,3 +217,20 @@ back atomically (replace the file). Every record must include a top-level `"run_
 field with format `synthesis_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on
 each stage update). Set `signoff_achieved: false` until the final sign-off stage
 completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/synthesis/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      synthesis_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-synthesis-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.

--- a/plugins/verification/skills/functional-verification/SKILL.md
+++ b/plugins/verification/skills/functional-verification/SKILL.md
@@ -25,6 +25,19 @@ Use the domain rules in this file only when the orchestrator reads this skill
 mid-flow for stage-specific guidance, or when the user asks a targeted reference
 question rather than requesting a full flow execution.
 
+## Pre-run Context
+
+Before executing or advising on **any** stage, read the following files if they exist:
+
+1. `memory/verification/knowledge.md` — known failure patterns, successful tool flags, PDK/tool quirks.
+   Incorporate its guidance into every stage decision. If absent, proceed without it.
+2. `memory/verification/run_state.md` — current run identity (`run_id`, `design_name`, `tool`,
+   `last_stage`). Use this to resume correctly after interruption. If absent, a new run
+   is starting; the orchestrator will create this file before the first stage.
+
+This pre-run read applies whether this skill is loaded by a user or called by the
+orchestrator mid-flow. It ensures the fix database is consulted before any diagnosis step.
+
 ## Purpose
 Guide the complete UVM functional verification flow from testbench architecture
 through coverage-closed regression sign-off. Produces a verified RTL package
@@ -293,3 +306,20 @@ without full orchestrator context.
 
 Use `run_id` = `verification_<YYYYMMDD>_<HHMMSS>` (set once at flow start; reuse on each
 stage update). Set `signoff_achieved: false` until the final sign-off stage completes.
+### Run state (write before first stage, update after each stage)
+Write `memory/verification/run_state.md` as the **first action** before launching any tool:
+```markdown
+run_id:      verification_<YYYYMMDD>_<HHMMSS>
+design_name: <design>
+tool:        <primary tool>
+start_time:  <ISO-8601>
+last_stage:  <first stage name>
+```
+Update `last_stage` after each stage completes. This file lets wakeup-loop prompts
+and resumed sessions identify the correct run without relying on in-memory state.
+Create the file and parent directories if they do not exist.
+
+### Optional: claude-mem index
+If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
+applied fix as an observation to entity `chip-design-verification-fixes` after writing to
+`experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.


### PR DESCRIPTION
## 📌 Description
Add pre-run context, run_state update, clock gating analysis and OpenROAD MCP update

## 🔗 Related Issue
NIL

## 🧪 Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement / refactor
- [x] Documentation update

## 🧠 What Changed?
- Add pre-run context & run_state sections in skills for all domains
- Add clock gating analysis to architecture and RTL-design domains
- Update OpenROAD MCP with setup instructions

## 🔄 Affected Areas
- [ ] Agent logic
- [ ] Workflow orchestration
- [ ] Scripts / tooling
- [ ] Documentation
- [ ] Other:

## ⚙️ How to Test
Provide a clear way to validate this PR:
NIL

## 📦 Outputs / Results
Describe any generated outputs or observable changes:
NIL

## ⚠️ Risks / Notes
NIL

## ✅ Checklist
- [x] Changes are scoped and minimal
- [x] Verified functionality manually or via tests
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

## 📎 Additional Context
NIL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clock-gating opportunity analysis with a clock-gating coverage QoR gate (≥60% for high-opportunity domains).
  * Improved run resumption: run state is persisted at run start and updated after each stage.
  * Optional indexed memory integration to publish applied fixes when available.

* **Documentation**
  * Updated Architecture→RTL handoff to include clock power budgeting.
  * Expanded domain workflows with pre-run context initialization and explicit clock-gating/ICG requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->