### PR TITLE
[Agent] Add persistent design state section across all agents

### DIFF
--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -63,7 +63,13 @@ Track tool versions, install paths, and MCP configuration choices across setups 
 
 Revisit if tool version mismatches cause repeated debugging across sessions.
 
-## 5. Central "Design" State
+## 5. Central "Design" State ✓ IMPLEMENTED
+
+**Status:** Shipped — all 14 orchestrators read `design_state.json` on entry and write their
+domain sub-object plus a `history[]` entry on exit. Schema covers `spec`, `interfaces`,
+`constraints`, `architecture`, `rtl`, `verification_status`, `synthesis`, `dft`, `sta`,
+`hls`, `pd`, `soc`, `compiler`, `firmware`, `fpga`, `environment`, `tool_feedback`,
+`pending_approval`, and `history[]`.
 
 Today each orchestrator maintains its own session-scoped state object. There is no shared
 artifact that survives an orchestrator boundary, so downstream agents cannot see upstream

--- a/memory/README.md
+++ b/memory/README.md
@@ -92,8 +92,7 @@ Key top-level fields:
 - `architecture`, `rtl`, `synthesis`, `sta`, `pd`, ... — per-domain signoff state
 - `history[]` — append-only execution trace; one entry per orchestrator run
 
-Atomic write protocol: read → modify → write `design_state.tmp` → rename to `design_state.json`.
-This matches the `experiences.jsonl` upsert pattern and prevents partial writes.
+Atomic write protocol with multi-writer protection: acquire an exclusive lock (e.g., flock or application-level mutex) around the entire read-modify-write sequence → read `design_state.json` (or {}) and record a version/checksum → modify → write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`) → re-check that the version/checksum of `design_state.json` is unchanged (or retry on mismatch) → rename temp to `design_state.json` while still holding the lock → release the lock. This prevents both partial writes and lost updates from concurrent orchestrators. Apply the same pattern to `experiences.jsonl` upsert operations if multiple writers can touch it.
 
 ## How Orchestrators Use This
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -78,6 +78,23 @@ memory/
 └── verification/
 ```
 
+## Design State
+
+`design_state.json` is a cross-orchestrator shared file written to the working directory.
+It persists spec, interfaces, constraints, and per-domain outputs across all 14 orchestrator
+boundaries. Every orchestrator reads it at session start (after `knowledge.md`) and performs
+an atomic read-modify-write at session end (alongside `experiences.jsonl`).
+
+Key top-level fields:
+- `spec` — raw and structured product specification (written by architecture)
+- `interfaces` — AXI/protocol interface list (written by architecture)
+- `constraints` — shared timing, area, and power targets (written by architecture)
+- `architecture`, `rtl`, `synthesis`, `sta`, `pd`, ... — per-domain signoff state
+- `history[]` — append-only execution trace; one entry per orchestrator run
+
+Atomic write protocol: read → modify → write `design_state.tmp` → rename to `design_state.json`.
+This matches the `experiences.jsonl` upsert pattern and prevents partial writes.
+
 ## How Orchestrators Use This
 
 **Session start**: Read `memory/<domain>/knowledge.md` and `memory/<domain>/run_state.md`

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -137,7 +137,7 @@ If the file does not exist or fields are null, proceed with empty upstream conte
 Do not fail if any key is absent — treat missing keys as null.
 
 ### Write (session end)
-On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+On any termination path (signoff, escalation, abandonment, max-turns, interruption, or error), perform an atomic
 read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
@@ -145,7 +145,7 @@ read-modify-write of `design_state.json`:
 4. Set `format_version: "1.0"` if not present.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
-7. Write to `design_state.tmp`, then rename to `design_state.json`.
+7. Acquire an exclusive lock (e.g., flock or application-level mutex) around the write sequence, write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`), then rename to `design_state.json` while still holding the lock, and finally release the lock to prevent lost updates from concurrent orchestrators.
 Create the file and parent directory if they do not exist.
 
 Domain fields to merge:

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -139,13 +139,17 @@ Do not fail if any key is absent — treat missing keys as null.
 ### Write (session end)
 On any termination path (signoff, escalation, abandonment, max-turns, interruption, or error), perform an atomic
 read-modify-write of `design_state.json`:
-1. Read the file if it exists, or start from `{}`.
-2. Set `design_name` (from your state object) if not already present.
-3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present.
-5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
-7. Acquire an exclusive lock (e.g., flock or application-level mutex) around the write sequence, write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`), then rename to `design_state.json` while still holding the lock, and finally release the lock to prevent lost updates from concurrent orchestrators.
+1. Acquire an exclusive lock (e.g., flock or application-level mutex) before the entire read-modify-write sequence.
+2. Read the file if it exists, or start from `{}`, and record its version/checksum.
+3. Set `design_name` (from your state object) if not already present.
+4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+5. Set `format_version: "1.0"` if not present.
+6. Merge your domain fields (below) into the top-level object.
+7. Append one entry to `history[]`.
+8. Re-check that the version/checksum of `design_state.json` is unchanged; if it changed, retry the read-modify-write loop.
+9. Write to a unique temp file using the pattern `design_state.<pid>.<uuid>.tmp`.
+10. Perform an atomic rename to `design_state.json` while still holding the lock.
+11. Release the lock only after the rename to prevent lost updates from concurrent orchestrators.
 Create the file and parent directory if they do not exist.
 
 Domain fields to merge:

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -125,3 +125,53 @@ line must be a valid JSON object followed by a newline:
 ```
 Set `signoff_achieved: false` on partial runs (interrupted, error, max-turns); set to `true` only
 on successful signoff. Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/architecture/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "spec": { "raw": "<user specification verbatim>", "structured": {} },
+  "interfaces": [ { "name": "...", "width": null, "role": "..." } ],
+  "constraints": { "clk_mhz": null, "area_um2": null, "power_mw": null },
+  "architecture": {
+    "selected_candidate": "<name of selected arch>",
+    "candidates": [],
+    "microarch_doc": "<path or inline summary>",
+    "signoff": false,
+    "refinement_needed": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "architecture-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -82,3 +82,49 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/compiler/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `architecture`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "compiler": {
+    "isa": "<ISA name or spec path>",
+    "toolchain_built": false,
+    "regression_pass_rate": null,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "compiler-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -84,3 +84,49 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/dft/knowledge.md`, read `design_state.json` if it exists.
+Extract: `rtl`, `synthesis`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "dft": {
+    "scan_coverage_pct": null,
+    "atpg_fault_coverage_pct": null,
+    "scandef": "<path to .scandef>",
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "dft-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -81,3 +81,49 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/firmware/knowledge.md`, read `design_state.json` if it exists.
+Extract: `rtl`, `soc`, `interfaces`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "firmware": {
+    "bsp_complete": false,
+    "rtos_ported": false,
+    "flash_size_kb": null,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "firmware-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -89,3 +89,47 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/formal/knowledge.md`, read `design_state.json` if it exists.
+Extract: `rtl`, `spec`, `interfaces`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge only `verification_status.formal_signoff` — do not overwrite `coverage_pct`,
+   `sim_signoff`, or `signoff` set by the verification orchestrator.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "verification_status": {
+    "formal_signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "formal-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -104,15 +104,17 @@ If the file does not exist or fields are null, proceed with empty upstream conte
 Do not fail if any key is absent — treat missing keys as null.
 
 ### Write (session end)
-On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+On any termination path (signoff, escalation, abandonment, max-turns, interruption, or error), perform an atomic, locked
 read-modify-write of `design_state.json`:
-1. Read the file if it exists, or start from `{}`.
-2. Set `design_name` (from your state object) if not already present.
-3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present.
-5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
-7. Write to `design_state.tmp`, then rename to `design_state.json`.
+1. Acquire an exclusive lock (e.g., flock or application-level mutex) around the entire read-modify-write sequence.
+2. Read the file if it exists, or start from `{}`.
+3. Set `design_name` (from your state object) if not already present.
+4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+5. Set `format_version: "1.0"` if not present.
+6. Merge your domain fields (below) into the top-level object.
+7. Append one entry to `history[]`.
+8. Write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`), then rename to `design_state.json` while still holding the lock.
+9. Release the lock to prevent lost updates from concurrent orchestrator exits.
 Create the file and parent directory if they do not exist.
 
 Domain fields to merge:

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -92,3 +92,50 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/fpga/knowledge.md`, read `design_state.json` if it exists.
+Extract: `rtl`, `synthesis`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "fpga": {
+    "target_fpga": "<vendor and part number>",
+    "lut_count": null,
+    "fmax_mhz": null,
+    "timing_met": false,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "fpga-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -90,3 +90,50 @@ After signoff (or on escalation/abandon), upsert (create or replace by `run_id`)
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/hls/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "hls": {
+    "top_function": "<C/C++ top function name>",
+    "latency_cycles": null,
+    "ii_cycles": null,
+    "dsp_count": null,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "hls-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -109,3 +109,46 @@ Each stage must return:
 3. If max iterations exceeded: stop, present full state and escalation report
 4. Never auto-run per-tool install scripts — present them to the user for review; each MISSING tool gets its own `install-<toolname>.sh` written to `install-missing-tools/`
 5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, `mcp-adapter.py` and `mcp-session-adapter.py` present, and all 10 MCP config snippets written with resolved absolute paths and printed
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+Read `design_state.json` if it exists in the working directory.
+Infrastructure does not depend on upstream domain outputs; no specific fields need extraction.
+If the file does not exist, proceed normally.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+3. Set `format_version: "1.0"` if not present.
+4. Merge your domain fields (below) into the top-level object.
+5. Append one entry to `history[]`.
+6. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "environment": {
+    "tools_validated": false,
+    "pdk_installed": null,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "infrastructure-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": null
+}
+```

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -122,3 +122,51 @@ Create the file and parent directories if they do not exist.
 If `mcp__plugin_ecc_memory__add_observations` is available in this session, emit each
 applied fix as an observation to entity `chip-design-pd-fixes` immediately after writing
 to `experiences.jsonl`. Skip silently if the tool is absent — JSONL is the canonical record.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/pd/knowledge.md`, read `design_state.json` if it exists.
+Extract: `synthesis`, `sta`, `dft`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "pd": {
+    "gds": "<path to GDS-II>",
+    "util_pct": null,
+    "wns_ns": null,
+    "drc_violations": 0,
+    "lvs_errors": 0,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "physical-design-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -90,3 +90,50 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/rtl-design/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `interfaces`, `constraints`, `architecture`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "rtl": {
+    "top_module": "<top-level module name>",
+    "files": ["<path/to/file.sv>"],
+    "lint_clean": false,
+    "cdc_clean": false,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "rtl-design-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -90,3 +90,49 @@ the current stage state:
 }
 ```
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/soc/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `interfaces`, `constraints`, `rtl`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "soc": {
+    "ip_blocks_integrated": 0,
+    "memory_map": null,
+    "simulation_pass": false,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "soc-integration-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -96,3 +96,50 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/sta/knowledge.md`, read `design_state.json` if it exists.
+Extract: `synthesis`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "sta": {
+    "setup_wns_ns": null,
+    "hold_wns_ns": null,
+    "tns_ns": null,
+    "corners_passed": [],
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "sta-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -86,3 +86,53 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/synthesis/knowledge.md`, read `design_state.json` if it exists.
+Extract: `rtl`, `constraints`, `environment`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) into the top-level object.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "synthesis": {
+    "tool": "<primary tool used>",
+    "pdk": "<pdk name>",
+    "netlist": "<path to gate-level netlist>",
+    "wns_ns": null,
+    "cells": null,
+    "area_um2": null,
+    "lec_unmatched": 0,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "synthesis-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -89,3 +89,49 @@ After signoff (or on escalation/abandon), append one JSON line to
 ```
 If the flow ends before signoff (interrupted, error, max turns exceeded), write the record immediately with the stages completed so far and `signoff_achieved: false`. Do not wait for a terminal signoff state.
 Create the file and parent directories if they do not exist.
+
+## Design State
+
+`design_state.json` in the working directory is the shared cross-orchestrator state file.
+
+### Read (session start)
+After reading `memory/verification/knowledge.md`, read `design_state.json` if it exists.
+Extract: `spec`, `rtl`, `interfaces`, `constraints`.
+If the file does not exist or fields are null, proceed with empty upstream context.
+Do not fail if any key is absent — treat missing keys as null.
+
+### Write (session end)
+On any termination path (signoff, escalation, abandonment, max-turns), perform an atomic
+read-modify-write of `design_state.json`:
+1. Read the file if it exists, or start from `{}`.
+2. Set `design_name` (from your state object) if not already present.
+3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
+4. Set `format_version: "1.0"` if not present.
+5. Merge your domain fields (below) — merge into the existing `verification_status` object
+   without overwriting `formal_signoff` if already set by the formal orchestrator.
+6. Append one entry to `history[]`.
+7. Write to `design_state.tmp`, then rename to `design_state.json`.
+Create the file and parent directory if they do not exist.
+
+Domain fields to merge:
+```json
+{
+  "verification_status": {
+    "coverage_pct": null,
+    "sim_signoff": false,
+    "signoff": false
+  }
+}
+```
+
+History entry to append:
+```json
+{
+  "timestamp": "<ISO-8601>",
+  "agent": "verification-orchestrator",
+  "stage": "<final stage reached>",
+  "decision": "proceed | escalate | abandoned",
+  "reason": "<one-sentence summary of outcome>",
+  "constraint_ref": "<constraint name or null>"
+}
+```


### PR DESCRIPTION
## 📌 Description
- Add persistent design state section across all agents
- Enable downstream features (continuous verification loop, constraint awareness, architecture refinement) in later implementation

## 🔗 Related Issue
Closes #31 

## 🧪 Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Improvement / refactor
- [x] Documentation update

## 🧠 What Changed?
- Add design state section into all agents
  - Reads upstream fields to extract from design_state.json on entry
  - Writes per-domain sub-object and history[] entry to append (Similar to experiences)
- Update documentations for new design state section

## 🔄 Affected Areas
- [x] Agent logic
- [ ] Workflow orchestration
- [ ] Scripts / tooling
- [x] Documentation
- [ ] Other:

## ⚙️ How to Test
NIL

## 📦 Outputs / Results
Describe any generated outputs or observable changes:
- Agents should generate/append into a design_state.json file so downstream agents can read and reference

## ⚠️ Risks / Notes
NIL

## ✅ Checklist
- [x] Changes are scoped and minimal
- [ ] Verified functionality manually or via tests
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

## 📎 Additional Context
NIL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Design State" section describing a shared cross-orchestrator state file: orchestrators read initial design/spec/constraints at session start and atomically persist merged, domain-specific progress, signoff flags and a structured history entry at session end to avoid partial writes and lost updates.

* **Chores**
  * Marked Central "Design State" as implemented and shipped in the roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->