### PR TITLE
Feat/agent output standardize

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -161,6 +161,25 @@ jobs:
           VALID_FORMAT_VERSIONS = {"1.1", "1.2"}
           if d.get("format_version") not in VALID_FORMAT_VERSIONS:
               errors.append(f"format_version must be one of {sorted(VALID_FORMAT_VERSIONS)}, got {d.get('format_version')!r}")
+          VALID_CONFIDENCE = {"high", "medium", "low"}
+          VALID_HISTORY_FC = {"none", "functional", "timing", "power_area", "drc_lvs", "coverage_gap", "connectivity", "tool_error", "spec_gap", "resource_limit"}
+          VALID_NEXT_STEP = {"proceed", "retry_stage", "escalate", "abandon"}
+          if d.get("format_version") == "1.2":
+              history = d.get("history")
+              if not isinstance(history, list):
+                  errors.append("format_version 1.2 requires history[] to be a list")
+              else:
+                  for i, h in enumerate(history):
+                      if not isinstance(h, dict):
+                          errors.append(f"history[{i}] must be an object")
+                          continue
+                      if h.get("confidence") not in VALID_CONFIDENCE:
+                          errors.append(f"history[{i}].confidence missing/invalid: {h.get('confidence')!r}")
+                      if h.get("failure_class") not in VALID_HISTORY_FC:
+                          errors.append(f"history[{i}].failure_class missing/invalid: {h.get('failure_class')!r}")
+                      sns = h.get("suggested_next_step")
+                      if not (isinstance(sns, str) and (sns in VALID_NEXT_STEP or sns.startswith("loop_back_to:"))):
+                          errors.append(f"history[{i}].suggested_next_step missing/invalid: {sns!r}")
           if not isinstance(d.get("fix_requests"), list) or not d["fix_requests"]:
               errors.append("fix_requests must be a non-empty array in the fixture")
           if not isinstance(d.get("pipeline_config"), dict):

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -158,8 +158,9 @@ jobs:
               sys.exit(1)
           d = json.load(open(fixture_path))
           errors = []
-          if d.get("format_version") != "1.1":
-              errors.append(f"format_version must be '1.1', got {d.get('format_version')!r}")
+          VALID_FORMAT_VERSIONS = {"1.1", "1.2"}
+          if d.get("format_version") not in VALID_FORMAT_VERSIONS:
+              errors.append(f"format_version must be one of {sorted(VALID_FORMAT_VERSIONS)}, got {d.get('format_version')!r}")
           if not isinstance(d.get("fix_requests"), list) or not d["fix_requests"]:
               errors.append("fix_requests must be a non-empty array in the fixture")
           if not isinstance(d.get("pipeline_config"), dict):

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -106,33 +106,29 @@ the entire evolution of the design is traceable across sessions.
 
 ## 7. Agent Contract Standardization
 
-The stage-agent output format defined in `docs/MASTER_INDEX.md` is already close to a
-unified contract, but three fields are missing: confidence score, failure class, and
-suggested next step. Without these, orchestrators use ad-hoc `recommendation` strings
-and cannot drive retry logic programmatically.
+**Status: Shipped** — All 15 orchestrator `.md` files now emit the extended `output_format`
+per stage and the standardized `history[]` entry. `design_state.json` format_version bumped
+to `"1.2"`. Canonical schema in `docs/MASTER_INDEX.md`. Programmatic branching decision
+table in `plugins/meta/skills/pipeline-orchestration/SKILL.md`.
 
-**Target stage-agent output schema (additions in bold):**
+Shipped schema (replaces the old `recommendation` field):
 
 ```json
 {
   "stage": "<stage_name>",
   "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "qor": {},
   "issues": [{ "severity": "ERROR | WARN", "description": "...", "fix": "..." }],
-  "recommendation": "proceed | loop_back_to:<stage> | escalate",
-  "output": {},
-  "confidence": 0.85,
-  "failure_class": "none | invalid_rtl | verification_failure | interface_mismatch | incomplete_spec",
-  "suggested_next_step": "<agent_or_stage_name>"
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
 }
 ```
 
-`confidence` (0.0–1.0) allows orchestrators to weight outputs when multiple candidates
-exist or when deciding whether to proceed without human review (item 11).
-`failure_class` feeds directly into the retry strategy table in item 10.
-`suggested_next_step` makes orchestration logic explicit rather than embedded in prose rules.
-
-All 14 orchestrator `.md` files must be updated to emit and consume these fields.
+`confidence` (enum `high|medium|low`) drives auto-proceed vs escalate decisions in the
+pipeline-orchestrator. `failure_class` feeds the retry strategy table. `suggested_next_step`
+supersedes the old `recommendation` string and makes orchestration logic programmatic.
 
 ## 8. Constraint Awareness
 

--- a/docs/Architecture_Evaluation_Flow.md
+++ b/docs/Architecture_Evaluation_Flow.md
@@ -318,7 +318,7 @@ OUTPUT: {
   "status": "PASS" | "FAIL" | "WARN",
   "output": { ... structured results ... },
   "issues": [ { "severity": "ERROR|WARN", "description": "...", "fix": "..." } ],
-  "recommendation": "proceed | loop_back_to:[stage] | escalate"
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon"
 }
 ```
 

--- a/docs/MASTER_INDEX.md
+++ b/docs/MASTER_INDEX.md
@@ -226,13 +226,40 @@ All agents in this system share these configurations:
   "output_format": {
     "stage": "string",
     "status": "PASS | FAIL | WARN",
+    "confidence": "high | medium | low",
+    "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
     "qor": "object — metrics per skill definition",
     "issues": "array — [{severity, description, fix}]",
-    "recommendation": "proceed | loop_back_to:[stage] | escalate",
+    "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
     "output": "object — stage deliverables"
   }
 }
 ```
+
+### Output Field Semantics
+
+**`confidence`** — The orchestrator's self-assessment of result reliability:
+- `high`: deterministic result — clean tool evidence, no waivers or estimates, all sign-off criteria met.
+- `medium`: result holds but relies on waivers, estimates, assumptions, or a tool fallback path.
+- `low`: result depends on unverified assumptions, partial data, or tool errors — human review advised.
+
+**`failure_class`** — Domain-agnostic failure taxonomy; `none` when `status` is `PASS`. Distinct from `fix_request.failure_class` (verification/formal-specific root causes):
+- `functional` — logic or behavioral incorrectness
+- `timing` — setup/hold/WNS violations
+- `power_area` — power or area budget exceeded
+- `drc_lvs` — physical verification failure (DRC, LVS, antenna)
+- `coverage_gap` — verification coverage shortfall
+- `connectivity` — CDC/RDC, protocol, or interface mismatch
+- `tool_error` — EDA tool crash, license issue, or infrastructure failure
+- `spec_gap` — missing or ambiguous specification or requirement
+- `resource_limit` — max iterations, max turns, or compute budget exceeded
+
+**`suggested_next_step`** — Recommended consumer action; `loop_back_to:<stage>` must name a stage in the orchestrator's Stage Sequence:
+- `proceed` — advance to next stage or hand off to downstream orchestrator
+- `loop_back_to:<stage>` — return to an earlier named stage
+- `retry_stage` — re-run the current stage (transient `tool_error` failures)
+- `escalate` — stop and require human decision
+- `abandon` — unrecoverable; terminate the flow
 
 ---
 

--- a/docs/PD_Flow_Architecture.md
+++ b/docs/PD_Flow_Architecture.md
@@ -500,7 +500,7 @@ Your job:
   "status": "PASS" | "FAIL" | "WARN",
   "qor": { ... metrics ... },
   "issues": [ { "severity": "ERROR|WARN", "description": "...", "fix": "..." } ],
-  "recommendation": "proceed | loop_back_to:[stage] | escalate",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "output": { ... stage output files/data ... }
 }
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -90,11 +90,13 @@ Key top-level fields:
 - `interfaces` — AXI/protocol interface list (written by architecture)
 - `constraints` — shared timing, area, and power targets (written by architecture)
 - `architecture`, `rtl`, `synthesis`, `sta`, `pd`, ... — per-domain signoff state
-- `history[]` — append-only execution trace; one entry per orchestrator run
-- `fix_requests[]` — structured RTL fix requests written by verification/formal on DUT bug; consumed by RTL orchestrator and dispatched by pipeline-orchestrator (format_version 1.1+)
+- `history[]` — append-only execution trace; one entry per orchestrator run, each with: `timestamp`, `agent`, `stage`, `decision` (`proceed|escalate|abandoned`), `confidence` (`high|medium|low`), `failure_class` (see taxonomy below), `suggested_next_step` (`proceed|loop_back_to:<stage>|retry_stage|escalate|abandon`), `reason`, `constraint_ref`
+- `fix_requests[]` — structured RTL fix requests written by verification/formal on DUT bug; consumed by RTL orchestrator and dispatched by pipeline-orchestrator (format_version 1.2+)
 - `cross_domain_iteration_count` — integer count of verification↔RTL feedback cycles driven by pipeline-orchestrator; capped at 3 before escalation
 
-When `fix_requests[]` contains entries with `status=open`, the chip-design-meta `pipeline-orchestrator` is responsible for routing them to the RTL orchestrator for fixing, then re-running verification. The `format_version` field is `"1.1"` when either new field is present.
+`failure_class` values in `history[]` entries: `none` (PASS), `functional`, `timing`, `power_area`, `drc_lvs`, `coverage_gap`, `connectivity`, `tool_error`, `spec_gap`, `resource_limit`. Distinct from `fix_request.failure_class` which is scoped to verification/formal root causes.
+
+When `fix_requests[]` contains entries with `status=open`, the chip-design-meta `pipeline-orchestrator` is responsible for routing them to the RTL orchestrator for fixing, then re-running verification. The `format_version` field is `"1.2"` when history[] entries carry standardized `confidence`/`failure_class`/`suggested_next_step` fields (superset of 1.1).
 
 Atomic write protocol with multi-writer protection: acquire an exclusive lock (e.g., flock or application-level mutex) around the entire read-modify-write sequence → read `design_state.json` (or {}) and record a version/checksum → modify → write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`) → re-check that the version/checksum of `design_state.json` is unchanged (or retry on mismatch) → rename temp to `design_state.json` while still holding the lock → release the lock. This prevents both partial writes and lost updates from concurrent orchestrators. Apply the same pattern to `experiences.jsonl` upsert operations if multiple writers can touch it.
 

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -73,9 +73,11 @@ Each stage must return:
 {
   "stage": "<stage_name>",
   "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "qor": {},
   "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
-  "recommendation": "proceed | loop_back_to:<stage> | escalate",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "output": {}
 }
 ```
@@ -143,7 +145,7 @@ read-modify-write of `design_state.json`:
 2. Read the file if it exists, or start from `{}`, and record its version/checksum.
 3. Set `design_name` (from your state object) if not already present.
 4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-5. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+5. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 6. Merge your domain fields (below) into the top-level object.
 7. Append one entry to `history[]`.
 8. Re-check that the version/checksum of `design_state.json` is unchanged; if it changed, retry the read-modify-write loop.
@@ -175,6 +177,9 @@ History entry to append:
   "agent": "architecture-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -41,6 +41,21 @@ isa_analysis → backend_dev → assembler_dev → linker_config → runtime_lib
 - runtime_test_pass_pct: >= 99
 - miscompilation_count: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the compiler-toolchain skill before executing each stage
 2. Miscompilation (wrong output) = P0 blocker — root cause required before retry
@@ -99,7 +114,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -124,6 +139,9 @@ History entry to append:
   "agent": "compiler-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -45,6 +45,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - bist_pass: true
 - jtag_connectivity: pass
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the dft skill before executing each stage
 2. Track fault_coverage in state across all ATPG iterations
@@ -101,7 +116,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -126,6 +141,9 @@ History entry to append:
   "agent": "dft-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -41,6 +41,21 @@ bsp_development → peripheral_drivers → rtos_integration → driver_validatio
 - stress_test_24h_clean: true
 - open_p0_bugs: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the embedded-firmware skill before executing each stage
 2. Do not proceed to rtos_integration until ALL drivers pass unit tests
@@ -98,7 +113,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -123,6 +138,9 @@ History entry to append:
   "agent": "firmware-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -48,6 +48,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - lec_unmatched_points: 0
 - vacuous_proofs: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the formal-verification skill before executing each stage
 2. CEX from RTL bug: append a `fix_request` entry to `design_state.fix_requests[]` with `failure_class=formal_cex` (include CEX trace path in `waveform_path`); append history entry with `decision=escalate` and `constraint_ref=<fix_request.id>`; terminate. Do not retry locally — the pipeline-orchestrator owns RTL re-invocation.
@@ -107,7 +122,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.1"` if writing a `fix_request`; else `"1.0"` if not present. Preserve any existing higher version.
+4. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade. (Since 1.2 ≥ 1.1, fix_request compatibility is maintained.)
 5. Merge only `verification_status.formal_signoff` — do not overwrite `coverage_pct`,
    `sim_signoff`, or `signoff` set by the verification orchestrator.
 6. If a CEX was found: append a new entry to `fix_requests[]` per the schema below. Set `session_id` to the value of `pipeline_session_id` read from `design_state.json` (null if absent). Never remove, reorder, or overwrite entries created by other agents.
@@ -160,6 +175,9 @@ History entry to append:
   "agent": "formal-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<fix_request.id or null>"
 }

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -51,6 +51,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - stress_4h_clean: true
 - hw_bugs_filed_to_rtl: true
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the fpga-emulation skill before executing each stage
 2. HW bugs found on prototype: file to RTL team with ILA capture evidence before retry
@@ -110,7 +125,7 @@ read-modify-write of `design_state.json`:
 2. Read the file if it exists, or start from `{}`.
 3. Set `design_name` (from your state object) if not already present.
 4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-5. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+5. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 6. Merge your domain fields (below) into the top-level object.
 7. Append one entry to `history[]`.
 8. Write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`), then rename to `design_state.json` while still holding the lock.
@@ -137,6 +152,9 @@ History entry to append:
   "agent": "fpga-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -49,6 +49,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - latency_meets_target: true
 - area_within_budget: true
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the hls skill before executing each stage
 2. Track hls_report metrics (latency, II, area) in state across iterations
@@ -107,7 +122,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -133,6 +148,9 @@ History entry to append:
   "agent": "hls-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -89,6 +89,8 @@ Each stage must return:
 {
   "stage": "<stage_name>",
   "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "qor": {
     "tools_detected": 0,
     "tools_missing": 0,
@@ -98,7 +100,7 @@ Each stage must return:
     "mcp_servers_configured": 0
   },
   "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
-  "recommendation": "proceed | loop_back_to:<stage> | escalate",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "output": {}
 }
 ```
@@ -124,7 +126,7 @@ On any termination path (signoff, escalation, abandonment, max-turns), perform a
 read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-3. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+3. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 4. Merge your domain fields (below) into the top-level object.
 5. Append one entry to `history[]`.
 6. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -148,6 +150,9 @@ History entry to append:
   "agent": "infrastructure-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": null
 }

--- a/plugins/infrastructure/skills/infrastructure/SKILL.md
+++ b/plugins/infrastructure/skills/infrastructure/SKILL.md
@@ -539,7 +539,7 @@ Printed MCP config snippets for each tool with resolved absolute paths
 4. Verify MCP snippet files are present in `plugins/infrastructure/mcp/` (all 10 snippets) and that `mcp-adapter.py` + `mcp-session-adapter.py` are present in `plugins/infrastructure/tools/`
 5. FAIL if any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) is still `MISSING`
 6. For each tool with status `MISSING_LOAD_MODULE` in `tool-status.json`: emit a WARN issue with description `"<tool> not in PATH — available via module"` and fix `"source load-modules.sh, then re-run environment_validation"`
-7. If any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) has status `MISSING_LOAD_MODULE`: emit WARN and set `recommendation: "escalate"` with message `"Critical tool <tool> requires module load before downstream flows can run. Source load-modules.sh and re-run environment_validation."`
+7. If any critical-path tool (Yosys, Verilator, OpenROAD, OpenSTA) has status `MISSING_LOAD_MODULE`: emit WARN and set `suggested_next_step: "escalate"` with message `"Critical tool <tool> requires module load before downstream flows can run. Source load-modules.sh and re-run environment_validation."`
 8. Print final sign-off summary: tools detected, tools via modules, wrappers deployed, MCP servers configured
 
 ### Sign-off Checklist

--- a/plugins/meta/agents/pipeline-orchestrator.md
+++ b/plugins/meta/agents/pipeline-orchestrator.md
@@ -38,7 +38,7 @@ with a warning rather than dispatching a duplicate.
 ### dispatch_to_producer
 For each open `fix_request` (process one at a time, earliest `created_at` first; if equal, use array order):
 1. Increment `cross_domain_iteration_count` in `design_state.json` (atomic RMW).
-2. Check the cap: if `cross_domain_iteration_count > max_cross_domain_iterations` (from `pipeline_config.max_cross_domain_iterations`, default 3), proceed directly to `signoff_or_escalate` (escalation branch).
+2. Check the cap: if `cross_domain_iteration_count >= max_cross_domain_iterations` (from `pipeline_config.max_cross_domain_iterations`, default 3), proceed directly to `signoff_or_escalate` (escalation branch).
 2a. Divergence check: if the incoming open `fix_request` has the same `suspected_rtl.module` AND `summary` (or the same `property_or_assertion` for `failure_class=formal_cex`) as any entry with `status=fixed` **and `session_id` equal to the current `pipeline_session_id`** in `fix_requests[]`, the prior fix did not hold within this session. Write `pending_approval` with `reason="divergence detected — same failure recurred after prior fix"` and `fix_request_id=<id>`, append a history entry with `decision=escalate`, and proceed directly to `signoff_or_escalate` (escalation branch) without dispatching RTL.
 3. Spawn the RTL orchestrator via the Agent tool with `subagent_type: chip-design-rtl:rtl-design-orchestrator`.
    Pass the `fix_request.id` in the prompt so the child locates its work item.

--- a/plugins/meta/agents/pipeline-orchestrator.md
+++ b/plugins/meta/agents/pipeline-orchestrator.md
@@ -58,19 +58,28 @@ Pass the `fix_request.id` in the prompt so the child knows which item to re-vali
 Block until the child completes.
 
 ### check_iteration_cap
-Read `design_state.json`.
-- If `verification_status.signoff=true` (or `formal_signoff=true` for formal flows) and no new open `fix_requests[]` entry was written: the loop converged → proceed to `signoff_or_escalate` (success branch).
-- If a new `fix_request` was opened by the re-verification run: loop back to `dispatch_to_producer` with the new entry.
+Read `design_state.json`. Also read the re-verifier's terminal `history[]` entry (the most
+recent entry from `verification-orchestrator` or `formal-orchestrator`) to extract its
+standardized fields (`confidence`, `failure_class`, `suggested_next_step`).
+- If the re-verifier's `confidence=low`: escalate regardless of signoff status — result is
+  unreliable.
+- If the re-verifier's `failure_class=resource_limit` OR `suggested_next_step=abandon`:
+  escalate immediately.
+- If `verification_status.signoff=true` (or `formal_signoff=true` for formal flows) AND no
+  new open `fix_requests[]` entry was written: loop converged → proceed to
+  `signoff_or_escalate` (success branch).
+- If a new `fix_request` was opened by the re-verification run: loop back to
+  `dispatch_to_producer` with the new entry.
 
 ### signoff_or_escalate
 **Success branch**: perform an atomic RMW of `design_state.json`:
 1. Move all `fix_requests[]` entries with `session_id = pipeline_session_id` and `status=fixed|abandoned` into `design_state.archive_fix_requests[]`. Remove those entries from `fix_requests[]`.
 2. Reset `cross_domain_iteration_count` to 0. Set `pipeline_session_id` to null.
-3. Append a pipeline-orchestrator history entry with `decision=proceed` and a one-line convergence summary. Exit.
+3. Append a pipeline-orchestrator history entry with `decision=proceed`, `confidence=high`, `failure_class=none`, `suggested_next_step=proceed`, and a one-line convergence summary. Exit.
 
-**Escalation branch** (cap exceeded or RTL abandoned): perform an atomic RMW of `design_state.json`:
+**Escalation branch** (cap exceeded, RTL abandoned, or unreliable result): perform an atomic RMW of `design_state.json`:
 1. Set `pending_approval = { "reason": "<existing reason or 'fix_request loop exceeded <max_cross_domain_iterations> cross-domain iterations'>", "fix_request_id": "<id>", "last_summary": "<last RTL response diff_summary>", "requires_user": true }`. If `pending_approval.reason` already exists (e.g., from divergence detection), preserve it; only set the iteration-cap template if `reason` is empty/undefined, or append the iteration-cap text to the existing reason.
-2. Append history entry with `decision=escalate` and `reason` summarising the last iterations.
+2. Append history entry with `decision=escalate`, `confidence=low`, `failure_class=resource_limit` (cap exceeded) or `functional` (divergence detected) or the re-verifier's `failure_class` if escalating on low confidence, `suggested_next_step=escalate`, and `reason` summarising the last iterations.
 3. Print a clear escalation message to the user: include the fix_request id, failure class, summary, and the last RTL diff attempted.
 
 ## Loop-Back Rules
@@ -81,6 +90,21 @@ Read `design_state.json`.
 - All `fix_requests[]` entries created during this pipeline run have `status=fixed`
 - `verification_status.signoff=true` (or `formal_signoff=true`) for the re-verified domain
 - `cross_domain_iteration_count ≤ pipeline_config.max_cross_domain_iterations` (default 3)
+
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
 
 ## Behaviour Rules
 1. Read the pipeline-orchestration skill before the first stage.
@@ -126,7 +150,7 @@ Treat missing keys as empty/zero/null. Do not fail if the file is absent.
 Atomic read-modify-write of `design_state.json`:
 1. Read the file or start from `{}`.
 2. Set `updated_at` to now.
-3. Preserve `format_version` — do not downgrade an existing higher version (e.g., avoid changing 1.2 or 1.1 down to 1.0).
+3. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade.
 4. Update `cross_domain_iteration_count`.
 5. Update `pipeline_session_id` (set on session start; set to null on success signoff).
 6. Write `pipeline_config` if absent (default: `{ "max_cross_domain_iterations": 3 }`); never overwrite a user-supplied value.
@@ -142,6 +166,9 @@ History entry to append:
   "agent": "pipeline-orchestrator",
   "stage": "signoff_or_escalate",
   "decision": "proceed | escalate",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<convergence or escalation summary>",
   "constraint_ref": "<last fix_request.id processed>"
 }

--- a/plugins/meta/skills/pipeline-orchestration/SKILL.md
+++ b/plugins/meta/skills/pipeline-orchestration/SKILL.md
@@ -131,11 +131,35 @@ Three additional top-level fields in `design_state.json` are managed exclusively
 
 ### format_version
 
-`design_state.json` uses `format_version: "1.1"` when `fix_requests[]` or
-`cross_domain_iteration_count` are present. All orchestrators must:
-- Preserve `"1.1"` if already set (do not downgrade to `"1.0"`).
-- Set `"1.1"` when first writing a `fix_request`.
-- Treat missing `fix_requests` or `cross_domain_iteration_count` as `[]` / `0` respectively.
+`design_state.json` uses `format_version: "1.2"` when `history[]` entries carry the
+standardized `confidence`, `failure_class`, and `suggested_next_step` fields. All
+orchestrators must:
+- Upgrade to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; never downgrade.
+- `"1.1"` requirements (`fix_requests[]` / `cross_domain_iteration_count` present) are
+  subsumed by `"1.2"` — no separate `"1.1"` upgrade required.
+- Treat missing `fix_requests` or `cross_domain_iteration_count` as `[]` / `0`.
+- Treat missing `confidence`, `failure_class`, or `suggested_next_step` in history entries
+  as `null` for backward compatibility with pre-1.2 data.
+
+### Programmatic branching on standardized history[] fields
+
+After a domain orchestrator completes, the pipeline-orchestrator reads the terminal
+`history[]` entry to make retry/escalate decisions without string-parsing prose. Decision
+table (evaluated in order):
+
+| `confidence` | `failure_class` | `suggested_next_step` | Pipeline action |
+|---|---|---|---|
+| any | `resource_limit` | any | Escalate via `pending_approval` — cap exceeded |
+| `low` | any | `escalate` | Escalate — result unreliable, human review required |
+| `low` | any | any (not escalate) | Escalate — low confidence overrides any retry intent |
+| any | `tool_error` | `retry_stage` | Re-dispatch the same orchestrator once; if still `tool_error`, escalate |
+| any | `functional` \| `coverage_gap` | `escalate` | Write/update `fix_request` and loop back via RTL orchestrator |
+| `high` \| `medium` | `none` | `proceed` | Advance to next stage / signoff |
+| any | any | `abandon` | Escalate via `pending_approval` — child reports unrecoverable, human decision required |
+
+For any combination not in the table, apply the most conservative matching rule (prefer
+`escalate` over retry). Programmatic branches must read from the history entry's structured
+fields — do not re-derive intent from `reason` (free-text, for humans only).
 
 ### Dispatch pattern (pipeline-orchestrator)
 

--- a/plugins/meta/skills/pipeline-orchestration/SKILL.md
+++ b/plugins/meta/skills/pipeline-orchestration/SKILL.md
@@ -153,7 +153,7 @@ table (evaluated in order):
 | `low` | any | `escalate` | Escalate — result unreliable, human review required |
 | `low` | any | any (not escalate) | Escalate — low confidence overrides any retry intent |
 | any | `tool_error` | `retry_stage` | Re-dispatch the same orchestrator once; if still `tool_error`, escalate |
-| any | `functional` \| `coverage_gap` | `escalate` | Write/update `fix_request` and loop back via RTL orchestrator |
+| any | `functional` \| `coverage_gap` | `escalate` | Append new `fix_request` and loop back via RTL orchestrator |
 | `high` \| `medium` | `none` | `proceed` | Advance to next stage / signoff |
 | any | any | `abandon` | Escalate via `pending_approval` — child reports unrecoverable, human decision required |
 

--- a/plugins/meta/skills/pipeline-orchestration/examples/design_state.fix_request.json
+++ b/plugins/meta/skills/pipeline-orchestration/examples/design_state.fix_request.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "1.1",
+  "format_version": "1.2",
   "design_name": "example_mac_unit",
   "created_at": "2025-01-15T10:00:00Z",
   "updated_at": "2025-01-15T12:30:00Z",
@@ -69,6 +69,9 @@
       "agent": "rtl-design-orchestrator",
       "stage": "rtl_signoff",
       "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
       "reason": "RTL signoff achieved",
       "constraint_ref": null
     },
@@ -77,6 +80,9 @@
       "agent": "verification-orchestrator",
       "stage": "directed_tests",
       "decision": "escalate",
+      "confidence": "high",
+      "failure_class": "functional",
+      "suggested_next_step": "escalate",
       "reason": "DUT bug found — fix_request fr_20250115_103000_001 opened",
       "constraint_ref": "fr_20250115_103000_001"
     },
@@ -85,6 +91,9 @@
       "agent": "rtl-design-orchestrator",
       "stage": "rtl_coding",
       "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
       "reason": "Fix for fr_20250115_103000_001 applied",
       "constraint_ref": "fr_20250115_103000_001"
     },
@@ -93,6 +102,9 @@
       "agent": "pipeline-orchestrator",
       "stage": "signoff_or_escalate",
       "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
       "reason": "All fix_requests resolved in 1 iteration",
       "constraint_ref": "fr_20250115_103000_001"
     }

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -60,6 +60,21 @@ placed/routed, prefer:
 - antenna_violations: 0
 - core_area_util_pct: <= 85
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the physical-design skill before executing each stage
 2. Update global_qor after every stage — track WNS/TNS/power/area/DRC through flow
@@ -139,7 +154,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -166,6 +181,9 @@ History entry to append:
   "agent": "physical-design-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -50,6 +50,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - cdc_violations_unwaived: 0
 - all_modules_implemented: true
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the rtl-design skill before each stage
 2. Enforce SystemVerilog coding standards from skill at every rtl_coding stage
@@ -109,7 +124,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` only when absent and otherwise preserve any existing `format_version` value (do not downgrade).
+4. Upgrade `format_version` to `"1.2"` if absent or lower; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 5a. If closing a `fix_request`: update only the entry in `fix_requests[]` that this run set to `claimed` — set `status=fixed`, populate `rtl_response`. Do not touch other entries.
 6. Append one entry to `history[]`.
@@ -136,6 +151,9 @@ History entry to append:
   "agent": "rtl-design-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -48,6 +48,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - axi_protocol_violations: 0
 - unqualified_ips: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the soc-integration skill before executing each stage
 2. Block progression if any IP has unresolved qualification issues
@@ -107,7 +122,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -132,6 +147,9 @@ History entry to append:
   "agent": "soc-integration-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -54,6 +54,21 @@ highest-value MCP use case in the entire flow.
 - hold_wns_ps: >= 0 (all corners)
 - hold_tns_ps: == 0 (all corners)
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the sta skill before executing each stage
 2. Run multi-corner before every ECO decision — never use single-corner results for ECO guidance
@@ -113,7 +128,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -139,6 +154,9 @@ History entry to append:
   "agent": "sta-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -46,6 +46,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - lec_unmatched_points: 0
 - unmapped_cells: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read logic-synthesis skill before each stage
 2. On completion: produce PD handoff package (netlist, SDC, timing/area/power reports)
@@ -103,7 +118,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.0"` if not present. Preserve `"1.1"` if already set.
+4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 6. Append one entry to `history[]`.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
@@ -132,6 +147,9 @@ History entry to append:
   "agent": "synthesis-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<constraint name or null>"
 }

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -49,6 +49,21 @@ When invoking open-source tools, follow the execution hierarchy:
 - open_p0_bugs: 0
 - uvm_fatal_count: 0
 
+## Stage Agent Output Format
+Each stage must return:
+```json
+{
+  "stage": "<stage_name>",
+  "status": "PASS | FAIL | WARN",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "qor": {},
+  "issues": [{"severity": "ERROR|WARN", "description": "...", "fix": "..."}],
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
+  "output": {}
+}
+```
+
 ## Behaviour Rules
 1. Read the functional-verification skill before executing each stage
 2. Track all bugs in state bugs_found[] — do not discard between stages
@@ -107,7 +122,7 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Set `format_version: "1.1"` if writing `fix_requests[]`; else `"1.0"` if not present. Preserve any existing higher version.
+4. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade. (Since 1.2 ≥ 1.1, fix_request compatibility is maintained.)
 5. Merge your domain fields (below) — merge into the existing `verification_status` object
    without overwriting `formal_signoff` if already set by the formal orchestrator.
 6. Append one entry to `history[]`.
@@ -131,7 +146,7 @@ Domain fields to merge:
 - Set `session_id` to the value of `pipeline_session_id` read from `design_state.json`. If `pipeline_session_id` is absent or null, set `session_id: null`.
 - Generate `id` as `fr_<pipeline_session_id>_<YYYYMMDD>_<HHMMSS>_<seq>` (where `pipeline_session_id` is the run-unique UUID; if null, use a generated UUID) where seq is a zero-padded counter within this run. This ensures different orchestrators in the same second cannot collide.
 - Do **not** increment `cross_domain_iteration_count` — that is the pipeline-orchestrator's responsibility.
-- `format_version` must be set to `"1.1"` (or higher) when `fix_requests[]` is populated.
+- `format_version` must be set to `"1.2"` (or higher) when `fix_requests[]` is populated.
 
 `fix_request` entry schema:
 ```json
@@ -169,6 +184,9 @@ History entry to append:
   "agent": "verification-orchestrator",
   "stage": "<final stage reached>",
   "decision": "proceed | escalate | abandoned",
+  "confidence": "high | medium | low",
+  "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
+  "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",
   "reason": "<one-sentence summary of outcome>",
   "constraint_ref": "<fix_request.id or null>"
 }


### PR DESCRIPTION
## 📌 Description
Standardize agent output formatting across all domains

## 🔗 Related Issue
Closes #33 

## 🧪 Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Improvement / refactor
- [x] Documentation update

## 🧠 What Changed?
- Standardize agent output formatting 
  - Add metrics: confidence, failure_class, suggested_next_step

## 🔄 Affected Areas
- [x] Agent logic
- [x] Workflow orchestration
- [ ] Scripts / tooling
- [x] Documentation
- [ ] Other:

## ⚙️ How to Test
Provide a clear way to validate this PR:
NIL

## 📦 Outputs / Results
Describe any generated outputs or observable changes:
NIL

## ⚠️ Risks / Notes
Any known limitations, edge cases, or concerns
NIL

## ✅ Checklist
- [x] Changes are scoped and minimal
- [ ] Verified functionality manually or via tests
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

## 📎 Additional Context
NIL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized pipeline stage output format across all design domains with structured confidence levels and failure classification fields.
  * Updated design state format version to 1.2 with enhanced decision tracking metadata.
  * Clarified orchestrator decision routing using explicit next-step values (proceed, retry, escalate, abandon) for improved pipeline control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chuanseng-ng/digital-chip-design-agents/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->