### PR TITLE
Feat/Add approval checkpoints & execution log tracing across domains

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -158,7 +158,7 @@ jobs:
               sys.exit(1)
           d = json.load(open(fixture_path))
           errors = []
-          VALID_FORMAT_VERSIONS = {"1.1", "1.2"}
+          VALID_FORMAT_VERSIONS = {"1.1", "1.2", "1.3"}
           if d.get("format_version") not in VALID_FORMAT_VERSIONS:
               errors.append(f"format_version must be one of {sorted(VALID_FORMAT_VERSIONS)}, got {d.get('format_version')!r}")
           VALID_CONFIDENCE = {"high", "medium", "low"}
@@ -180,6 +180,26 @@ jobs:
                       sns = h.get("suggested_next_step")
                       if not (isinstance(sns, str) and (sns in VALID_NEXT_STEP or sns.startswith("loop_back_to:"))):
                           errors.append(f"history[{i}].suggested_next_step missing/invalid: {sns!r}")
+          if d.get("format_version") == "1.3":
+              pc = d.get("pipeline_config", {})
+              if "checkpoints" in pc and not isinstance(pc["checkpoints"], list):
+                  errors.append("pipeline_config.checkpoints must be a list if present")
+              elif "checkpoints" in pc:
+                  for i, ck in enumerate(pc["checkpoints"]):
+                      if not isinstance(ck, str):
+                          errors.append(f"pipeline_config.checkpoints[{i}] must be a string")
+              ac = d.get("approved_checkpoints")
+              if ac is not None:
+                  if not isinstance(ac, list):
+                      errors.append("approved_checkpoints must be a list if present")
+                  else:
+                      for i, entry in enumerate(ac):
+                          if not isinstance(entry, dict) or "stage" not in entry:
+                              errors.append(f"approved_checkpoints[{i}] must be an object with 'stage'")
+              pa = d.get("pending_approval")
+              if pa is not None:
+                  if pa.get("type") not in {"checkpoint", "escalation"}:
+                      errors.append(f"pending_approval.type must be 'checkpoint' or 'escalation', got {pa.get('type')!r}")
           if not isinstance(d.get("fix_requests"), list) or not d["fix_requests"]:
               errors.append("fix_requests must be a non-empty array in the fixture")
           if not isinstance(d.get("pipeline_config"), dict):
@@ -202,6 +222,47 @@ jobs:
               for e in errors: print(f"ERROR: {e}", file=sys.stderr)
               sys.exit(1)
           print(f"OK: {fixture_path} — {len(d['fix_requests'])} fix_request(s), format_version={d['format_version']!r}")
+
+          # Validate checkpoint fixture (format_version 1.3)
+          checkpoint_fixture = "plugins/meta/skills/pipeline-orchestration/examples/design_state.checkpoint.json"
+          if not os.path.isfile(checkpoint_fixture):
+              print(f"ERROR: checkpoint fixture not found: {checkpoint_fixture}", file=sys.stderr)
+              sys.exit(1)
+          c = json.load(open(checkpoint_fixture))
+          cerrors = []
+          if c.get("format_version") not in VALID_FORMAT_VERSIONS:
+              cerrors.append(f"format_version must be one of {sorted(VALID_FORMAT_VERSIONS)}, got {c.get('format_version')!r}")
+          if c.get("format_version") == "1.3":
+              pc = c.get("pipeline_config", {})
+              if not isinstance(pc.get("checkpoints"), list):
+                  cerrors.append("pipeline_config.checkpoints must be a list in 1.3 fixture")
+              ac = c.get("approved_checkpoints")
+              if ac is None or not isinstance(ac, list):
+                  cerrors.append("approved_checkpoints must be a list in 1.3 fixture")
+              else:
+                  for i, entry in enumerate(ac):
+                      if not isinstance(entry, dict) or "stage" not in entry:
+                          cerrors.append(f"approved_checkpoints[{i}] must have 'stage'")
+              pa = c.get("pending_approval")
+              if pa is not None and pa.get("type") not in {"checkpoint", "escalation"}:
+                  cerrors.append(f"pending_approval.type invalid: {pa.get('type')!r}")
+              hist = c.get("history", [])
+              if not isinstance(hist, list) or len(hist) == 0:
+                  cerrors.append("history[] must be a non-empty list in 1.3 fixture")
+              else:
+                  for i, h in enumerate(hist):
+                      if not isinstance(h, dict): continue
+                      if h.get("confidence") not in VALID_CONFIDENCE:
+                          cerrors.append(f"history[{i}].confidence invalid: {h.get('confidence')!r}")
+                      if h.get("failure_class") not in VALID_HISTORY_FC:
+                          cerrors.append(f"history[{i}].failure_class invalid: {h.get('failure_class')!r}")
+                      sns = h.get("suggested_next_step")
+                      if not (isinstance(sns, str) and (sns in VALID_NEXT_STEP or sns.startswith("loop_back_to:"))):
+                          cerrors.append(f"history[{i}].suggested_next_step invalid: {sns!r}")
+          if cerrors:
+              for e in cerrors: print(f"ERROR (checkpoint fixture): {e}", file=sys.stderr)
+              sys.exit(1)
+          print(f"OK: {checkpoint_fixture} — format_version={c.get('format_version')!r}, {len(c.get('history', []))} history entries")
           PYEOF
 
       - name: Validate IDE config files

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude files
 .claude/*
+CLAUDE.md
 
 # Python files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased] — feat/approval-gates-traceability branch
+
+### Added
+
+- **Approval checkpoints** (FUTURE_WORK item 11, part A): proactive human-in-the-loop gates at any orchestrator's sign-off boundary, controlled by `pipeline_config.checkpoints[]` in `design_state.json`. Default positions: `arch_signoff`, `rtl_signoff`, and `signoff` (PD tape-out). When a checkpoint fires, the orchestrator sets `pending_approval { type: "checkpoint", stage, agent }` and halts without completing sign-off; the user resumes by adding the stage to `approved_checkpoints[]` and re-invoking. Empty `checkpoints` ⇒ fully autonomous (backward compatible).
+- **Per-stage execution trace** (FUTURE_WORK item 11, part B): all 15 orchestrators now append one `history[]` entry per completed stage (PASS/FAIL/WARN) rather than a single terminal entry per run. Enables post-run audits without replaying the full agent conversation. Entry shape is unchanged (9-field schema).
+- **`format_version "1.3"`**: new capability tier in `design_state.json` covering checkpoints + per-stage trace. All orchestrators upgrade to `"1.3"` on first write; prior-version files remain readable.
+- **`design_state.checkpoint.json` fixture**: new golden example under `plugins/meta/skills/pipeline-orchestration/examples/` demonstrating a `pending_approval { type: "checkpoint" }` pause, `approved_checkpoints[]` entry, and per-stage history trace across architecture → RTL stages.
+
+### Changed
+
+- **`pending_approval` schema extended**: added `type` (`checkpoint` | `escalation`), `stage`, and `agent` fields. Backward-compatible — readers treating missing `type` as `"escalation"` remain correct.
+- **Ownership rules amended**: domain orchestrators may now set `pending_approval` with `type: "checkpoint"` at their own sign-off stage; `type: "escalation"` remains the sole responsibility of the pipeline-orchestrator.
+- **`pipeline_config` extended**: added `checkpoints` array (list of stage name strings, default `[]`).
+- **`approved_checkpoints[]` added**: new top-level field; each entry `{ "stage", "approved_at", "approved_by" }`. Written by the user or by an orchestrator acting on an explicit approval instruction.
+- **All 15 orchestrators updated**: Design State Read now extracts `pipeline_config` and `approved_checkpoints`; Design State Write upgrades `format_version` to `"1.3"`; all orchestrators carry two new Behaviour Rules (per-stage trace + checkpoint gate).
+- **CI validation extended**: `VALID_FORMAT_VERSIONS` now includes `"1.3"`; new inline Python checks for `pipeline_config.checkpoints`, `approved_checkpoints`, `pending_approval.type`; both fixtures validated on every PR.
+- **`memory/README.md`** updated with `format_version 1.3` tier, `checkpoints`, `approved_checkpoints`, and extended `pending_approval` field documentation.
+
+---
+
 ## [Unreleased] — feat/rtl-verify-feedback-loop branch
 
 ### Added

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -198,11 +198,16 @@ structured way to distinguish a recoverable code error from an ambiguous spec.
 
 **Prerequisite:** item 7 (failure_class field in output contract).
 
-## 11. Human-in-the-loop Control Points + Observability
+## ~~11. Human-in-the-loop Control Points + Observability~~ ✓ DONE (format_version 1.3)
 
-Currently the only human interaction points are invocation and max-iteration escalation.
+~~Currently the only human interaction points are invocation and max-iteration escalation.
 There are no optional approval gates between pipeline stages, and there is no structured
-record of why an agent made a particular decision.
+record of why an agent made a particular decision.~~
+
+Implemented in format_version 1.3: `pipeline_config.checkpoints` config, `approved_checkpoints[]` resume
+list, `pending_approval.type` discriminator, per-stage `history[]` trace (one entry per stage),
+and checkpoint gate logic in all 15 orchestrators. See `plugins/meta/skills/pipeline-orchestration/SKILL.md`
+§ Approval Checkpoints.
 
 ### Approval Checkpoints
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -90,13 +90,21 @@ Key top-level fields:
 - `interfaces` — AXI/protocol interface list (written by architecture)
 - `constraints` — shared timing, area, and power targets (written by architecture)
 - `architecture`, `rtl`, `synthesis`, `sta`, `pd`, ... — per-domain signoff state
-- `history[]` — append-only execution trace; one entry per orchestrator run, each with: `timestamp`, `agent`, `stage`, `decision` (`proceed|escalate|abandoned`), `confidence` (`high|medium|low`), `failure_class` (see taxonomy below), `suggested_next_step` (`proceed|loop_back_to:<stage>|retry_stage|escalate|abandon`), `reason`, `constraint_ref`
+- `history[]` — append-only execution trace; one entry per **stage** (not per run — as of format_version 1.3), each with: `timestamp`, `agent`, `stage`, `decision` (`proceed|escalate|abandoned|await_approval`), `confidence` (`high|medium|low`), `failure_class` (see taxonomy below), `suggested_next_step` (`proceed|loop_back_to:<stage>|retry_stage|escalate|abandon`), `reason`, `constraint_ref`
 - `fix_requests[]` — structured RTL fix requests written by verification/formal on DUT bug; consumed by RTL orchestrator and dispatched by pipeline-orchestrator (format_version 1.2+)
 - `cross_domain_iteration_count` — integer count of verification↔RTL feedback cycles driven by pipeline-orchestrator; capped at 3 before escalation
+- `pipeline_config.checkpoints` — list of stage names requiring human approval before the orchestrator may declare signoff (format_version 1.3+). Empty/absent ⇒ fully autonomous. Example: `["arch_signoff", "rtl_signoff", "signoff"]`. Written by user; never overwritten by orchestrators.
+- `approved_checkpoints[]` — checkpoints cleared by the user. Each entry: `{ "stage": "<name>", "approved_at": "<ISO-8601>", "approved_by": "user" }` (format_version 1.3+).
+- `pending_approval` — non-null when a human decision is required. Field `type` distinguishes: `"checkpoint"` (proactive gate set by a domain orchestrator at its sign-off boundary) vs `"escalation"` (failure-driven, set by pipeline-orchestrator). Additional fields: `stage` (checkpoint stage name or null), `agent` (orchestrator that set it), `reason`, `fix_request_id`, `last_summary`, `requires_user`.
 
 `failure_class` values in `history[]` entries: `none` (PASS), `functional`, `timing`, `power_area`, `drc_lvs`, `coverage_gap`, `connectivity`, `tool_error`, `spec_gap`, `resource_limit`. Distinct from `fix_request.failure_class` which is scoped to verification/formal root causes.
 
-When `fix_requests[]` contains entries with `status=open`, the chip-design-meta `pipeline-orchestrator` is responsible for routing them to the RTL orchestrator for fixing, then re-running verification. The `format_version` field is `"1.2"` when history[] entries carry standardized `confidence`/`failure_class`/`suggested_next_step` fields (superset of 1.1).
+`format_version` tiers:
+- `"1.1"` — `fix_requests[]` and `cross_domain_iteration_count` present
+- `"1.2"` — history entries carry standardized `confidence`/`failure_class`/`suggested_next_step`
+- `"1.3"` — `pipeline_config.checkpoints`, `approved_checkpoints[]`, `pending_approval.type/stage/agent`; per-stage history entries (one per stage, not one per run)
+
+When `fix_requests[]` contains entries with `status=open`, the chip-design-meta `pipeline-orchestrator` is responsible for routing them to the RTL orchestrator for fixing, then re-running verification.
 
 Atomic write protocol with multi-writer protection: acquire an exclusive lock (e.g., flock or application-level mutex) around the entire read-modify-write sequence → read `design_state.json` (or {}) and record a version/checksum → modify → write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`) → re-check that the version/checksum of `design_state.json` is unchanged (or retry on mismatch) → rename temp to `design_state.json` while still holding the lock → release the lock. This prevents both partial writes and lost updates from concurrent orchestrators. Apply the same pattern to `experiences.jsonl` upsert operations if multiple writers can touch it.
 

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -88,6 +88,8 @@ Each stage must return:
 3. If max iterations exceeded: stop, present full state and escalation report
 4. On completion: produce microarchitecture document and RTL handoff package
 5. Read `memory/architecture/knowledge.md` before the first stage. Write an experience record to `memory/architecture/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `arch_signoff` only, unless invoked in fix-request-servicing mode — i.e. a `fix_request.id` was passed in the prompt): before setting `architecture.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"arch_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "arch_signoff", "agent": "architecture-orchestrator", "reason": "checkpoint arch_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: selected arch, estimated MHz, area>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `architecture.signoff=true`. On re-invocation: if `"arch_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -134,7 +136,7 @@ on successful signoff. Create the file and parent directories if they do not exi
 
 ### Read (session start)
 After reading `memory/architecture/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `constraints`.
+Extract: `spec`, `constraints`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -145,9 +147,9 @@ read-modify-write of `design_state.json`:
 2. Read the file if it exists, or start from `{}`, and record its version/checksum.
 3. Set `design_name` (from your state object) if not already present.
 4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-5. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+5. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 6. Merge your domain fields (below) into the top-level object.
-7. Append one entry to `history[]`.
+7. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 8. Re-check that the version/checksum of `design_state.json` is unchanged; if it changed, retry the read-modify-write loop.
 9. Write to a unique temp file using the pattern `design_state.<pid>.<uuid>.tmp`.
 10. Perform an atomic rename to `design_state.json` while still holding the lock.

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -62,6 +62,8 @@ Each stage must return:
 3. Implement backend in order: registers → integer ISA → calling convention → FPU → custom instructions
 4. Output: toolchain release package + validation report + ABI spec
 5. Read `memory/compiler/knowledge.md` before the first stage. Write an experience record to `memory/compiler/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `toolchain_signoff` only): before setting `compiler.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"toolchain_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "toolchain_signoff", "agent": "compiler-orchestrator", "reason": "checkpoint toolchain_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: regression_pass_rate, miscompilation_count>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `compiler.signoff=true`. On re-invocation: if `"toolchain_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -104,7 +106,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/compiler/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `architecture`.
+Extract: `spec`, `architecture`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -114,9 +116,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -140,7 +140,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "compiler-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -66,6 +66,8 @@ Each stage must return:
 3. Do not proceed to dft_signoff until SAF coverage meets target
 4. Output: DFT netlist, .scandef, ATPG patterns, BSDL file
 5. Read `memory/dft/knowledge.md` before the first stage. Write an experience record to `memory/dft/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `dft_signoff` only): before setting `dft.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"dft_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "dft_signoff", "agent": "dft-orchestrator", "reason": "checkpoint dft_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: SAF coverage, BIST pass status>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `dft.signoff=true`. On re-invocation: if `"dft_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -106,7 +108,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/dft/knowledge.md`, read `design_state.json` if it exists.
-Extract: `rtl`, `synthesis`.
+Extract: `rtl`, `synthesis`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -116,9 +118,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -62,6 +62,8 @@ Each stage must return:
 3. Track drivers_complete[] in state — partial driver list blocks RTOS stage
 4. Output: validated firmware package + bring-up guide + known issues list
 5. Read `memory/firmware/knowledge.md` before the first stage. Write an experience record to `memory/firmware/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `firmware_signoff` only): before setting `firmware.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"firmware_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "firmware_signoff", "agent": "firmware-orchestrator", "reason": "checkpoint firmware_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: all_driver_tests_pass, stress_test_24h_clean>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `firmware.signoff=true`. On re-invocation: if `"firmware_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -103,7 +105,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/firmware/knowledge.md`, read `design_state.json` if it exists.
-Extract: `rtl`, `soc`, `interfaces`.
+Extract: `rtl`, `soc`, `interfaces`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -113,9 +115,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -69,6 +69,8 @@ Each stage must return:
 3. Flag any unproven P0 property as a hard blocker for sign-off
 4. Vacuity check required after every environment_setup iteration
 5. Read `memory/formal/knowledge.md` before the first stage. Write an experience record to `memory/formal/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `formal_signoff` only, **unless** a `fix_request.id` was passed in the prompt — skip the gate in fix-request-servicing mode): before setting `verification_status.formal_signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"formal_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "formal_signoff", "agent": "formal-orchestrator", "reason": "checkpoint formal_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: proved/failed/unknown properties>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `verification_status.formal_signoff=true`. On re-invocation: if `"formal_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -111,7 +113,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/formal/knowledge.md`, read `design_state.json` if it exists.
-Extract: `rtl`, `spec`, `interfaces`, `fix_requests`, `pipeline_session_id`.
+Extract: `rtl`, `spec`, `interfaces`, `fix_requests`, `pipeline_session_id`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 If re-invoked by the pipeline-orchestrator: filter `fix_requests[]` for the current `fix_request.id` (or current `pipeline_session_id`) and, if applicable, the orchestrator identifier (`created_by=formal-orchestrator`). Re-run the failing property on the corrected RTL only for that specific entry. If the property passes, keep that entry's `status` as `fixed` and proceed. If it still fails, create a new `fix_request` entry for the continued failure.
@@ -122,11 +124,11 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade. (Since 1.2 ≥ 1.1, fix_request compatibility is maintained.)
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge only `verification_status.formal_signoff` — do not overwrite `coverage_pct`,
    `sim_signoff`, or `signoff` set by the verification orchestrator.
 6. If a CEX was found: append a new entry to `fix_requests[]` per the schema below. Set `session_id` to the value of `pipeline_session_id` read from `design_state.json` (null if absent). Never remove, reorder, or overwrite entries created by other agents.
-7. Append one entry to `history[]`.
+7. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 8. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -73,6 +73,8 @@ Each stage must return:
 4. All performance measurements: record at prototype frequency with scale factor noted
 5. Output: prototype sign-off report + HW bug report for RTL team + performance baseline
 6. Read `memory/fpga/knowledge.md` before the first stage. Write an experience record to `memory/fpga/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+7. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+8. Checkpoint gate (at `proto_signoff` only): before setting `fpga.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"proto_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "proto_signoff", "agent": "fpga-orchestrator", "reason": "checkpoint proto_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: lut_count, fmax_mhz, timing_met>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `fpga.signoff=true`. On re-invocation: if `"proto_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -114,7 +116,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/fpga/knowledge.md`, read `design_state.json` if it exists.
-Extract: `rtl`, `synthesis`, `constraints`.
+Extract: `rtl`, `synthesis`, `constraints`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -125,9 +127,9 @@ read-modify-write of `design_state.json`:
 2. Read the file if it exists, or start from `{}`.
 3. Set `design_name` (from your state object) if not already present.
 4. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-5. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+5. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 6. Merge your domain fields (below) into the top-level object.
-7. Append one entry to `history[]`.
+7. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 7); if not yet written (abrupt termination), append it now.
 8. Write to a unique temp file (e.g., `design_state.<pid>.<uuid>.tmp`), then rename to `design_state.json` while still holding the lock.
 9. Release the lock to prevent lost updates from concurrent orchestrator exits.
 Create the file and parent directory if they do not exist.

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -70,6 +70,8 @@ Each stage must return:
 3. Co-simulation output mismatch is always a blocker — root cause before retry
 4. Output: HLS RTL package + co-sim report + interface documentation
 5. Read `memory/hls/knowledge.md` before the first stage. Write an experience record to `memory/hls/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `hls_signoff` only): before setting `hls.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"hls_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "hls_signoff", "agent": "hls-orchestrator", "reason": "checkpoint hls_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: latency_cycles, ii_cycles, cosim_match>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `hls.signoff=true`. On re-invocation: if `"hls_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -112,7 +114,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/hls/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `constraints`.
+Extract: `spec`, `constraints`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -122,9 +124,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -120,7 +120,7 @@ Each stage must return:
 
 ### Read (session start)
 Read `design_state.json` if it exists in the working directory.
-Infrastructure does not depend on upstream domain outputs; extract `pipeline_config`, `approved_checkpoints` for the checkpoint gate (Behaviour Rule 6).
+Infrastructure does not depend on upstream domain outputs; extract `pipeline_config`, `approved_checkpoints` for the checkpoint gate (Behaviour Rule 7).
 If the file does not exist, proceed normally.
 
 ### Write (session end)
@@ -151,7 +151,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "infrastructure-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -111,6 +111,8 @@ Each stage must return:
 3. If max iterations exceeded: stop, present full state and escalation report
 4. Never auto-run per-tool install scripts — present them to the user for review; each MISSING tool gets its own `install-<toolname>.sh` written to `install-missing-tools/`
 5. On completion: confirm `tool-manifest.json` written, all 8 wrappers executable, `mcp-adapter.py` and `mcp-session-adapter.py` present, and all 10 MCP config snippets written with resolved absolute paths and printed
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `environment_validation` only): before setting `environment.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"environment_validation"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "environment_validation", "agent": "infrastructure-orchestrator", "reason": "checkpoint environment_validation requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: tools_detected, wrappers_deployed>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `environment.signoff=true`. On re-invocation: if `"environment_validation"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Design State
 
@@ -118,7 +120,7 @@ Each stage must return:
 
 ### Read (session start)
 Read `design_state.json` if it exists in the working directory.
-Infrastructure does not depend on upstream domain outputs; no specific fields need extraction.
+Infrastructure does not depend on upstream domain outputs; extract `pipeline_config`, `approved_checkpoints` for the checkpoint gate (Behaviour Rule 6).
 If the file does not exist, proceed normally.
 
 ### Write (session end)
@@ -126,9 +128,9 @@ On any termination path (signoff, escalation, abandonment, max-turns), perform a
 read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-3. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+3. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 4. Merge your domain fields (below) into the top-level object.
-5. Append one entry to `history[]`.
+5. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 6. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/meta/agents/pipeline-orchestrator.md
+++ b/plugins/meta/agents/pipeline-orchestrator.md
@@ -26,7 +26,10 @@ detect_open_fix_requests → dispatch_to_producer → await_completion → re_ve
 ## Stage Descriptions
 
 ### detect_open_fix_requests
-First, read `design_state.json` and check if `pending_approval` is non-null. If so, print the prior escalation message to the user and exit without dispatching — the user must clear `pending_approval` (set to `null`) and reset `cross_domain_iteration_count` to 0 before re-invoking.
+First, read `design_state.json` and check if `pending_approval` is non-null. If so, print a type-specific message and exit without dispatching:
+- `type: "checkpoint"`: "Checkpoint `<pending_approval.stage>` is awaiting human approval (set by `<pending_approval.agent>`). Approve or skip to continue — see pipeline-orchestration skill for resume paths."
+- `type: "escalation"` (or absent — backward compatibility): print the prior escalation summary.
+The user must clear `pending_approval` (set to `null`) before re-invoking; for escalation type also reset `cross_domain_iteration_count` to 0.
 Read `design_state.json`. Collect all entries in `fix_requests[]` with `status=open`.
 If none found, exit cleanly with a one-line summary. Do not modify the file.
 Guard against concurrent invocations: if any entry has `status=claimed` and its `updated_at`
@@ -78,7 +81,7 @@ standardized fields (`confidence`, `failure_class`, `suggested_next_step`).
 3. Append a pipeline-orchestrator history entry with `decision=proceed`, `confidence=high`, `failure_class=none`, `suggested_next_step=proceed`, and a one-line convergence summary. Exit.
 
 **Escalation branch** (cap exceeded, RTL abandoned, or unreliable result): perform an atomic RMW of `design_state.json`:
-1. Set `pending_approval = { "reason": "<existing reason or 'fix_request loop exceeded <max_cross_domain_iterations> cross-domain iterations'>", "fix_request_id": "<id>", "last_summary": "<last RTL response diff_summary>", "requires_user": true }`. If `pending_approval.reason` already exists (e.g., from divergence detection), preserve it; only set the iteration-cap template if `reason` is empty/undefined, or append the iteration-cap text to the existing reason.
+1. Set `pending_approval = { "type": "escalation", "stage": null, "agent": "pipeline-orchestrator", "reason": "<existing reason or 'fix_request loop exceeded <max_cross_domain_iterations> cross-domain iterations'>", "fix_request_id": "<id>", "last_summary": "<last RTL response diff_summary>", "requires_user": true }`. If `pending_approval.reason` already exists (e.g., from divergence detection), preserve it; only set the iteration-cap template if `reason` is empty/undefined, or append the iteration-cap text to the existing reason.
 2. Append history entry with `decision=escalate`, `confidence=low`, `failure_class=resource_limit` (cap exceeded) or `functional` (divergence detected) or the re-verifier's `failure_class` if escalating on low confidence, `suggested_next_step=escalate`, and `reason` summarising the last iterations.
 3. Print a clear escalation message to the user: include the fix_request id, failure class, summary, and the last RTL diff attempted.
 
@@ -143,14 +146,14 @@ Create the file and parent directories if they do not exist.
 `design_state.json` in the working directory is the shared cross-orchestrator state file.
 
 ### Read (session start)
-Read `design_state.json`. Extract: `fix_requests`, `cross_domain_iteration_count`, `pending_approval`, `pipeline_session_id`, `pipeline_config`.
+Read `design_state.json`. Extract: `fix_requests`, `cross_domain_iteration_count`, `pending_approval`, `pipeline_session_id`, `pipeline_config`, `approved_checkpoints`.
 Treat missing keys as empty/zero/null. Do not fail if the file is absent.
 
 ### Write (session end)
 Atomic read-modify-write of `design_state.json`:
 1. Read the file or start from `{}`.
 2. Set `updated_at` to now.
-3. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade.
+3. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 4. Update `cross_domain_iteration_count`.
 5. Update `pipeline_session_id` (set on session start; set to null on success signoff).
 6. Write `pipeline_config` if absent (default: `{ "max_cross_domain_iterations": 3 }`); never overwrite a user-supplied value.

--- a/plugins/meta/skills/pipeline-orchestration/SKILL.md
+++ b/plugins/meta/skills/pipeline-orchestration/SKILL.md
@@ -95,7 +95,9 @@ All entries in `design_state.fix_requests[]` must conform to this schema:
 
 - `rtl-design-orchestrator` owns the `open→claimed` and `claimed→fixed|abandoned` transitions.
 - Only the `rtl-design-orchestrator` sets `status=claimed→fixed` or `claimed→abandoned`.
-- Only the `pipeline-orchestrator` sets `cross_domain_iteration_count`, `pipeline_session_id`, `pipeline_config`, `pending_approval`, and moves resolved entries to `archive_fix_requests[]`.
+- Only the `pipeline-orchestrator` sets `cross_domain_iteration_count`, `pipeline_session_id`, `pipeline_config`, and moves resolved entries to `archive_fix_requests[]`.
+- Domain orchestrators **may** set `pending_approval` exclusively with `type: "checkpoint"` at their own sign-off stage; `type: "escalation"` remains the sole responsibility of the `pipeline-orchestrator`.
+- `approved_checkpoints[]` is written by the user (or by an orchestrator executing an explicit approval instruction) and read by all orchestrators.
 - All agents may append to `fix_request.history[]` but must not overwrite each other's entries.
 
 ### Iteration cap
@@ -107,6 +109,9 @@ verification↔RTL dispatch cycles for the current pipeline session. The cap is 
 ```json
 {
   "pending_approval": {
+    "type": "escalation",
+    "stage": null,
+    "agent": "pipeline-orchestrator",
     "reason": "fix_request loop exceeded 3 cross-domain iterations",
     "fix_request_id": "<id>",
     "last_summary": "<last rtl_response.diff_summary>",
@@ -122,24 +127,100 @@ before invoking the pipeline-orchestrator again. Optionally increase
 
 ### Pipeline session fields
 
-Three additional top-level fields in `design_state.json` are managed exclusively by the `pipeline-orchestrator`:
+Top-level fields in `design_state.json` managed by the `pipeline-orchestrator` and related infrastructure:
 
 - **`pipeline_session_id`** (`"ps_<YYYYMMDD>_<HHMMSS>"` or `null`): identifies the active pipeline run. Set on entry, cleared (set to null) on successful signoff. Scopes divergence checks and archival to the current session — entries from prior sessions are ignored by the divergence check.
 - **`pipeline_config`** (`object`): user-tunable pipeline settings. Written with defaults on first run; never overwritten if already present.
   - `max_cross_domain_iterations` (integer, default 3): the iteration cap for the feedback loop.
+  - `checkpoints` (array of strings, default `[]`): stage names that require human approval before the producing orchestrator may declare sign-off. Empty array ⇒ fully autonomous (preserves today's behavior). Example default: `["arch_signoff", "rtl_signoff", "signoff"]`. Written by the user; domain orchestrators read but never overwrite this field.
+- **`approved_checkpoints[]`**: list of stages the user has approved. Schema per entry: `{ "stage": "<stage name>", "approved_at": "<ISO-8601>", "approved_by": "user" }`. Written by the user (or by an orchestrator acting on an explicit approval instruction); read by all orchestrators at their sign-off gate check.
 - **`archive_fix_requests[]`**: resolved entries from completed pipeline sessions, moved here by the pipeline-orchestrator on successful signoff. Same schema as `fix_requests[]`. Never written by domain orchestrators.
 
 ### format_version
 
-`design_state.json` uses `format_version: "1.2"` when `history[]` entries carry the
-standardized `confidence`, `failure_class`, and `suggested_next_step` fields. All
-orchestrators must:
-- Upgrade to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; never downgrade.
-- `"1.1"` requirements (`fix_requests[]` / `cross_domain_iteration_count` present) are
-  subsumed by `"1.2"` — no separate `"1.1"` upgrade required.
+`design_state.json` version tiers (each tier is a superset of the previous):
+- **`"1.1"`**: `fix_requests[]` and `cross_domain_iteration_count` present.
+- **`"1.2"`**: `history[]` entries carry standardized `confidence`, `failure_class`, and `suggested_next_step` fields.
+- **`"1.3"`**: `pipeline_config.checkpoints`, `approved_checkpoints[]`, `pending_approval.type/stage/agent` present; per-stage `history[]` entries (one entry per completed stage, not just one terminal entry per run).
+
+All orchestrators must:
+- Upgrade to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; never downgrade.
+- All prior-version requirements are subsumed by `"1.3"` — no separate upgrades required.
 - Treat missing `fix_requests` or `cross_domain_iteration_count` as `[]` / `0`.
-- Treat missing `confidence`, `failure_class`, or `suggested_next_step` in history entries
-  as `null` for backward compatibility with pre-1.2 data.
+- Treat missing `confidence`, `failure_class`, or `suggested_next_step` in history entries as `null` for backward compatibility.
+- Treat missing `pipeline_config.checkpoints` as `[]` (no checkpoints — fully autonomous).
+- Treat missing `approved_checkpoints` as `[]`.
+- Treat missing `pending_approval.type` as `"escalation"` for backward compatibility.
+
+### Approval Checkpoints
+
+Proactive human-in-the-loop gates at configurable stage boundaries. Orthogonal to the
+failure-driven `pending_approval` (type `escalation`) set by the pipeline-orchestrator.
+
+#### Checkpoint configuration
+
+```json
+{
+  "pipeline_config": {
+    "checkpoints": ["arch_signoff", "rtl_signoff", "signoff"]
+  },
+  "approved_checkpoints": [
+    { "stage": "arch_signoff", "approved_at": "<ISO-8601>", "approved_by": "user" }
+  ]
+}
+```
+
+Default: `checkpoints: []` → no gates, fully autonomous (backward compatible).
+
+#### Gate logic (applied by every domain orchestrator at its sign-off stage)
+
+Before setting the domain's `signoff=true` and writing it to `design_state.json`:
+
+1. **Skip the gate in fix-request-servicing mode**: if a `fix_request.id` was passed in the
+   prompt (invoked by meta to repair a bug), skip the checkpoint check entirely. Checkpoints
+   gate forward design progression, not the automated verify↔RTL repair loop.
+
+2. Read `pipeline_config.checkpoints` from `design_state.json`. If the orchestrator's
+   sign-off stage name appears in the list **and** does not appear in `approved_checkpoints[].stage`:
+   - Atomic RMW: set `pending_approval`:
+     ```json
+     {
+       "type": "checkpoint",
+       "stage": "<sign-off stage name>",
+       "agent": "<this-orchestrator>",
+       "reason": "checkpoint <stage> requires human approval before proceeding",
+       "fix_request_id": null,
+       "last_summary": "<QoR one-liner>",
+       "requires_user": true
+     }
+     ```
+   - Append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`,
+     `failure_class: "none"`, `suggested_next_step: "escalate"`, `reason: "checkpoint <stage> requires human approval"`.
+   - **Do not** set `signoff=true`. Print the gate message to the user and halt.
+
+3. On re-invocation: if the stage now appears in `approved_checkpoints[]`, clear
+   `pending_approval` (atomic RMW → set to `null`), then proceed to set `signoff=true`.
+
+#### Resume paths
+
+The user may resume a gated orchestrator by either:
+- **Manual edit**: append `{ "stage": "<stage>", "approved_at": "<ISO-8601>", "approved_by": "user" }` to `approved_checkpoints[]` and set `pending_approval=null` in `design_state.json`, then re-invoke the orchestrator.
+- **Approval instruction**: invoke the orchestrator with "approve checkpoint `<stage>`" in the prompt — the orchestrator performs the `approved_checkpoints[]` append and `pending_approval` clear (atomic RMW) itself, then continues.
+
+#### pending_approval type-awareness (pipeline-orchestrator)
+
+The `pipeline-orchestrator`'s `detect_open_fix_requests` halts on **any** non-null
+`pending_approval` (conservative — a domain checkpoint also blocks meta dispatch). It prints
+a type-specific message:
+- `type: "checkpoint"`: "Checkpoint `<stage>` is awaiting human approval (set by `<agent>`). Approve or skip to continue."
+- `type: "escalation"`: (existing message) "Fix-request loop escalation — review required."
+
+#### Per-stage history trace (format_version 1.3)
+
+Every domain orchestrator appends one `history[]` entry after each internal stage completes
+(PASS, FAIL, WARN), not just at session end. The last entry written is the terminal entry
+read by the pipeline-orchestrator's decision table. Entry shape is unchanged (same 9-field
+schema). This enables post-run audits without replaying the full conversation.
 
 ### Programmatic branching on standardized history[] fields
 

--- a/plugins/meta/skills/pipeline-orchestration/examples/design_state.checkpoint.json
+++ b/plugins/meta/skills/pipeline-orchestration/examples/design_state.checkpoint.json
@@ -1,0 +1,185 @@
+{
+  "format_version": "1.3",
+  "design_name": "example_dsp_core",
+  "created_at": "2026-05-01T09:00:00Z",
+  "updated_at": "2026-05-01T11:45:00Z",
+  "cross_domain_iteration_count": 0,
+  "pipeline_session_id": null,
+  "pipeline_config": {
+    "max_cross_domain_iterations": 3,
+    "checkpoints": ["arch_signoff", "rtl_signoff", "signoff"]
+  },
+  "approved_checkpoints": [
+    { "stage": "arch_signoff", "approved_at": "2026-05-01T10:30:00Z", "approved_by": "user" }
+  ],
+  "pending_approval": {
+    "type": "checkpoint",
+    "stage": "rtl_signoff",
+    "agent": "rtl-design-orchestrator",
+    "reason": "checkpoint rtl_signoff requires human approval before proceeding",
+    "fix_request_id": null,
+    "last_summary": "lint_errors: 0, cdc_violations: 0, 4 modules implemented",
+    "requires_user": true
+  },
+  "fix_requests": [],
+  "archive_fix_requests": [],
+  "architecture": {
+    "selected_candidate": "pipelined_mac_array",
+    "candidates": [],
+    "microarch_doc": "docs/dsp_core_microarch.md",
+    "signoff": true,
+    "refinement_needed": false
+  },
+  "rtl": {
+    "top_module": "dsp_core",
+    "files": ["rtl/dsp_core.sv", "rtl/mac_unit.sv", "rtl/acc_bank.sv", "rtl/ctrl_fsm.sv"],
+    "lint_clean": true,
+    "cdc_clean": true,
+    "signoff": false
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-01T09:00:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "spec_analysis",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Product spec parsed — 256-tap FIR, 500 MHz target, 28nm PDK",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T09:20:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "arch_exploration",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "3 candidates evaluated; pipelined_mac_array selected for best PPA balance",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T09:45:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "perf_modelling",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "gem5 model shows 520 MHz achievable with 4-stage pipeline",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T10:05:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "power_area_estimation",
+      "decision": "proceed",
+      "confidence": "medium",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "McPAT estimate: 1.8 mm², 85 mW — within 90% of budget",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T10:15:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "risk_assessment",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "No HIGH risks; clock domain crossing mitigated by sync cells",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T10:25:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "arch_signoff",
+      "decision": "await_approval",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "escalate",
+      "reason": "checkpoint arch_signoff requires human approval before proceeding",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T10:32:00Z",
+      "agent": "architecture-orchestrator",
+      "stage": "arch_signoff",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "arch_signoff approved by user — architecture.signoff set to true",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T10:40:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "module_planning",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Module hierarchy defined: dsp_core, mac_unit, acc_bank, ctrl_fsm",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T11:00:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "rtl_coding",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "All 4 modules implemented in SystemVerilog",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T11:15:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "lint_check",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Verilator lint: 0 errors, 2 warnings (waived)",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T11:25:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "cdc_rdc_analysis",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "0 unwaived CDC violations — sync cells in place",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T11:35:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "synth_check",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Yosys synth_check: WNS +0.3 ns, area within estimate",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-05-01T11:45:00Z",
+      "agent": "rtl-design-orchestrator",
+      "stage": "rtl_signoff",
+      "decision": "await_approval",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "escalate",
+      "reason": "checkpoint rtl_signoff requires human approval before proceeding",
+      "constraint_ref": null
+    }
+  ]
+}

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -81,6 +81,8 @@ Each stage must return:
 3. Never proceed past a FAIL without applying the loop-back rule
 4. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report
 5. Read `memory/pd/knowledge.md` before the first stage. Write an experience record to `memory/pd/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `signoff` only): before setting `pd.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "signoff", "agent": "physical-design-orchestrator", "reason": "checkpoint signoff requires human approval before tape-out proceeds", "fix_request_id": null, "last_summary": "<QoR one-liner: WNS, DRC violations, util_pct>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `pd.signoff=true`. On re-invocation: if `"signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -144,7 +146,7 @@ to `experiences.jsonl`. Skip silently if the tool is absent — JSONL is the can
 
 ### Read (session start)
 After reading `memory/pd/knowledge.md`, read `design_state.json` if it exists.
-Extract: `synthesis`, `sta`, `dft`, `constraints`.
+Extract: `synthesis`, `sta`, `dft`, `constraints`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -154,9 +156,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -82,7 +82,7 @@ Each stage must return:
 4. Output: GDS-II, sign-off STA report, DRC clean, LVS clean, power report
 5. Read `memory/pd/knowledge.md` before the first stage. Write an experience record to `memory/pd/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
-7. Checkpoint gate (at `signoff` only): before setting `pd.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "signoff", "agent": "physical-design-orchestrator", "reason": "checkpoint signoff requires human approval before tape-out proceeds", "fix_request_id": null, "last_summary": "<QoR one-liner: WNS, DRC violations, util_pct>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `pd.signoff=true`. On re-invocation: if `"signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
+7. Checkpoint gate (at `signoff` only): before setting `pd.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"pd_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "pd_signoff", "agent": "physical-design-orchestrator", "reason": "checkpoint pd_signoff requires human approval before tape-out proceeds", "fix_request_id": null, "last_summary": "<QoR one-liner: WNS, DRC violations, util_pct>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `pd.signoff=true`. On re-invocation: if `"pd_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -182,7 +182,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "physical-design-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -72,6 +72,8 @@ Each stage must return:
 4. Output: RTL package (filelist.f, all .sv files, assertions, lint/CDC reports)
 5. Read `memory/rtl-design/knowledge.md` before the first stage. Write an experience record to `memory/rtl-design/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
 6. When closing a claimed `fix_request`: set `status=fixed`, populate `rtl_response` (diff_summary, files_changed, fixed_at), append an entry to that fix_request's `history[]`. Use `constraint_ref=<fix_request.id>` in the top-level `history[]` entry. Do not modify any `fix_requests[]` entry not set to `claimed` by this run.
+7. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+8. Checkpoint gate (at `rtl_signoff` only, **unless** a `fix_request.id` was passed in the prompt — skip the gate in fix-request-servicing mode): before setting `rtl.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"rtl_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "rtl_signoff", "agent": "rtl-design-orchestrator", "reason": "checkpoint rtl_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: lint/CDC status, module count>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `rtl.signoff=true`. On re-invocation: if `"rtl_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -113,7 +115,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/rtl-design/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `interfaces`, `constraints`, `architecture`, `fix_requests`.
+Extract: `spec`, `interfaces`, `constraints`, `architecture`, `fix_requests`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 If `fix_requests[]` contains any entry with `status=open` AND `created_by ∈ {verification-orchestrator, formal-orchestrator}`: first look up the incoming `fix_request.id` (if dispatched explicitly) and if that entry exists, has `status=open` and `created_by ∈ {verification-orchestrator, formal-orchestrator}`, set that entry's `status=claimed` and `updated_at` and proceed to `rtl_coding` using its scope (`suspected_rtl.module/file/line_range`) and context (`summary + expected_behavior + observed_behavior`). Only if no valid dispatched `fix_request.id` is present, apply the earliest-by-`created_at` fallback (tie-breaker by array order) to pick and claim an entry. Do not modify entries not owned by you.
@@ -124,10 +126,10 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if absent or lower; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
 5a. If closing a `fix_request`: update only the entry in `fix_requests[]` that this run set to `claimed` — set `status=fixed`, populate `rtl_response`. Do not touch other entries.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 7); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -152,7 +152,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "rtl-design-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -69,6 +69,8 @@ Each stage must return:
 3. Track ip_status{} per IP in state — never proceed with unqualified IP
 4. Output: integrated SoC RTL package ready for synthesis
 5. Read `memory/soc/knowledge.md` before the first stage. Write an experience record to `memory/soc/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `integration_signoff` only): before setting `soc.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"integration_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "integration_signoff", "agent": "soc-integration-orchestrator", "reason": "checkpoint integration_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: ip_blocks_integrated, sim_pass_rate>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `soc.signoff=true`. On re-invocation: if `"integration_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -112,7 +114,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/soc/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `interfaces`, `constraints`, `rtl`.
+Extract: `spec`, `interfaces`, `constraints`, `rtl`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -122,9 +124,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -148,7 +148,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "soc-integration-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -155,7 +155,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "sta-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -76,6 +76,8 @@ Each stage must return:
 4. ECO count > 2% of cells: hard stop, escalate to physical design team
 5. Do not enter eco_guidance if any exception in exception_review is pending sign-off — block until resolved
 6. Read `memory/sta/knowledge.md` before the first stage. Write an experience record to `memory/sta/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+7. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+8. Checkpoint gate (at `sta_signoff` only): before setting `sta.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"sta_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "sta_signoff", "agent": "sta-orchestrator", "reason": "checkpoint sta_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: setup_wns_ns, hold_wns_ns, tns_ns>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `sta.signoff=true`. On re-invocation: if `"sta_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -118,7 +120,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/sta/knowledge.md`, read `design_state.json` if it exists.
-Extract: `synthesis`, `constraints`.
+Extract: `synthesis`, `constraints`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -128,9 +130,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 7); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -66,6 +66,8 @@ Each stage must return:
 2. On completion: produce PD handoff package (netlist, SDC, timing/area/power reports)
 3. LEC must be run after every netlist change — not just at sign-off
 4. Read `memory/synthesis/knowledge.md` before the first stage. Write an experience record to `memory/synthesis/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+5. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+6. Checkpoint gate (at `synthesis_signoff` only): before setting `synthesis.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"synthesis_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "synthesis_signoff", "agent": "synthesis-orchestrator", "reason": "checkpoint synthesis_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: WNS, cells, area_um2>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `synthesis.signoff=true`. On re-invocation: if `"synthesis_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -108,7 +110,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/synthesis/knowledge.md`, read `design_state.json` if it exists.
-Extract: `rtl`, `constraints`, `environment`.
+Extract: `rtl`, `constraints`, `environment`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 
@@ -118,9 +120,9 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or currently `"1.0"` or `"1.1"`; preserve any higher version without downgrade.
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) into the top-level object.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 5); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -148,7 +148,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "synthesis-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -70,6 +70,8 @@ Each stage must return:
 3. Do not proceed to regression_signoff if any P0/P1 bugs remain open
 4. Bug found during directed tests: append a `fix_request` entry to `design_state.fix_requests[]` per the schema in the Design State section below; set `verification_status.signoff=false`; append a history entry with `decision=escalate` and `constraint_ref=<fix_request.id>`; then terminate this run. Do not retry locally — the pipeline-orchestrator owns RTL re-invocation.
 5. Read `memory/verification/knowledge.md` before the first stage. Write an experience record to `memory/verification/experiences.jsonl` whenever the flow terminates — including signoff, escalation, max-iterations exceeded, early error, or user interruption. If signoff was not achieved, set `signoff_achieved: false` and populate only the stages that completed.
+6. Per-stage trace: after each stage completes (PASS, FAIL, or WARN), atomically append one `history[]` entry to `design_state.json` using the stage's output `confidence`, `failure_class`, and `suggested_next_step`. Use the 9-field schema shown in the Design State section below. The last entry written is the terminal entry read by downstream orchestrators.
+7. Checkpoint gate (at `regression_signoff` only, **unless** a `fix_request.id` was passed in the prompt — skip the gate in fix-request-servicing mode): before setting `verification_status.signoff=true`, read `pipeline_config.checkpoints` and `approved_checkpoints` from `design_state.json`. If `"regression_signoff"` is in `checkpoints` and not in `approved_checkpoints[].stage`: (a) atomic RMW — set `pending_approval = { "type": "checkpoint", "stage": "regression_signoff", "agent": "verification-orchestrator", "reason": "checkpoint regression_signoff requires human approval before proceeding", "fix_request_id": null, "last_summary": "<QoR one-liner: coverage_pct, regression_failures>", "requires_user": true }`, (b) append a `history[]` entry with `decision: "await_approval"`, `confidence: "high"`, `failure_class: "none"`, `suggested_next_step: "escalate"`, (c) print the gate message, (d) halt without setting `verification_status.signoff=true`. On re-invocation: if `"regression_signoff"` is now in `approved_checkpoints[].stage`, clear `pending_approval` (set null) and proceed.
 
 ## Memory
 
@@ -111,7 +113,7 @@ Create the file and parent directories if they do not exist.
 
 ### Read (session start)
 After reading `memory/verification/knowledge.md`, read `design_state.json` if it exists.
-Extract: `spec`, `rtl`, `interfaces`, `constraints`, `fix_requests`, `pipeline_session_id`.
+Extract: `spec`, `rtl`, `interfaces`, `constraints`, `fix_requests`, `pipeline_session_id`, `pipeline_config`, `approved_checkpoints`.
 If the file does not exist or fields are null, proceed with empty upstream context.
 Do not fail if any key is absent — treat missing keys as null.
 If re-invoked by the pipeline-orchestrator: filter `fix_requests[]` for the specific dispatched `fix_request.id` (or at minimum filter by the current `pipeline_session_id` and the latest related request). Re-run the regression on the corrected RTL for that specific entry. If regression passes, leave that `fix_request.status` as `fixed` and proceed to `regression_signoff`. If regression still fails, create a new `fix_request` entry (do not update the old one) so the pipeline-orchestrator can dispatch another RTL cycle.
@@ -122,10 +124,10 @@ read-modify-write of `design_state.json`:
 1. Read the file if it exists, or start from `{}`.
 2. Set `design_name` (from your state object) if not already present.
 3. Set `created_at` (ISO-8601) if not present; set `updated_at` to now.
-4. Upgrade `format_version` to `"1.2"` if not present or lower; preserve any higher version without downgrade. (Since 1.2 ≥ 1.1, fix_request compatibility is maintained.)
+4. Upgrade `format_version` to `"1.3"` if absent or currently `"1.0"`, `"1.1"`, or `"1.2"`; preserve any higher version without downgrade.
 5. Merge your domain fields (below) — merge into the existing `verification_status` object
    without overwriting `formal_signoff` if already set by the formal orchestrator.
-6. Append one entry to `history[]`.
+6. Confirm the terminal `history[]` entry for the final stage was written by the per-stage trace (Behaviour Rule 6); if not yet written (abrupt termination), append it now.
 7. Write to `design_state.tmp`, then rename to `design_state.json`.
 Create the file and parent directory if they do not exist.
 

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -185,7 +185,7 @@ History entry to append:
   "timestamp": "<ISO-8601>",
   "agent": "verification-orchestrator",
   "stage": "<final stage reached>",
-  "decision": "proceed | escalate | abandoned",
+  "decision": "proceed | escalate | abandoned | await_approval",
   "confidence": "high | medium | low",
   "failure_class": "none | functional | timing | power_area | drc_lvs | coverage_gap | connectivity | tool_error | spec_gap | resource_limit",
   "suggested_next_step": "proceed | loop_back_to:<stage> | retry_stage | escalate | abandon",


### PR DESCRIPTION
## 📌 Description
All domain stages will have their own approval checkpoints & execution trace log for better debug and tracking
Subsequent stages can refer to previous stages' reports to determine approach

## 🔗 Related Issue
Closes #37 

## 🧪 Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Improvement / refactor
- [x] Documentation update

## 🧠 What Changed?
- Improved on history[] field
- Add human-in-the-loop checkpoints to reduce risk of deviation

## 🔄 Affected Areas
- [x] Agent logic
- [x] Workflow orchestration
- [ ] Scripts / tooling
- [x] Documentation
- [ ] Other:

## ⚙️ How to Test
Provide a clear way to validate this PR:
NIL

## 📦 Outputs / Results
Describe any generated outputs or observable changes:
- Agents will start to ask user to review status after each stage

## ⚠️ Risks / Notes
Any known limitations, edge cases, or concerns
NIL

## ✅ Checklist
- [x] Changes are scoped and minimal
- [x] Verified functionality manually or via tests
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

## 📎 Additional Context
Anything reviewers should know
NIL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkpoint-based approval gates added to sign-off stages across orchestrators; per-stage execution tracing now records confidence, failure class, and suggested next steps; design state format version 1.3 introduced with pipeline checkpoints, approved checkpoints, and pending-approval fields

* **Documentation**
  * Orchestrator specs, pipeline orchestration skill, examples, and memory docs updated to describe checkpoints, approval flows, and per-stage history semantics

* **Chores**
  * CI validation extended to enforce format_version 1.3 schema and checkpoint rules; VCS ignore list updated to exclude an additional file

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chuanseng-ng/digital-chip-design-agents/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->