### PR TITLE
Add npm distribution channel with cross-platform Node installer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions in .github/workflows/ up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      # Batch routine action bumps into a single PR to reduce noise; majors
+      # still come as separate PRs so they can be reviewed individually.
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -94,7 +94,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: digital-chip-design-agents-${{ steps.version.outputs.VERSION }}.tar.gz
           body_path: release_notes.md
@@ -114,11 +114,15 @@ jobs:
     steps:
       - name: Checkout
         if: env.NPM_TOKEN != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # The publish job only reads, stamps locally, and runs `npm publish` —
+          # it never pushes to git, so the GITHUB_TOKEN need not be persisted.
+          persist-credentials: false
 
       - name: Set up Node.js
         if: env.NPM_TOKEN != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,52 @@ jobs:
           prerelease: ${{ contains(steps.version.outputs.VERSION, 'rc') || contains(steps.version.outputs.VERSION, 'beta') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: validate
+    # Only runs when an NPM_TOKEN secret is configured; otherwise it is skipped.
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout
+        if: env.NPM_TOKEN != ''
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        if: env.NPM_TOKEN != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Extract version
+        if: env.NPM_TOKEN != ''
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Stamp tag version into package.json and manifests
+        if: env.NPM_TOKEN != ''
+        run: |
+          node -e "
+          const fs = require('fs');
+          const tag = process.env.VERSION.replace(/^v/, '');
+          const stamp = (p, mut) => { const d = JSON.parse(fs.readFileSync(p)); mut(d); fs.writeFileSync(p, JSON.stringify(d, null, 2) + '\n'); };
+          stamp('package.json', d => d.version = tag);
+          stamp('.claude-plugin/marketplace.json', d => d.metadata.version = tag);
+          for (const dir of fs.readdirSync('plugins')) {
+            const p = 'plugins/' + dir + '/.claude-plugin/plugin.json';
+            if (fs.existsSync(p)) stamp(p, d => d.version = tag);
+          }
+          console.log('Stamped version ' + tag);
+          "
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+
+      - name: Publish to npm
+        if: env.NPM_TOKEN != ''
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # This workflow runs on pull_request and executes repo code
+          # (distill.py via exec_module), so don't leave the token in git config.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ plugin into your Claude Code plugin cache and enables them in `settings.json`,
 then you restart Claude Code:
 
 ```bash
-npx @chuanseng-ng/digital-chip-design-agents
+npx digital-chip-design-agents
 ```
 
 Re-run the same command to pick up future updates. Works identically on macOS,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,23 @@
 
 ## Install
 
-### Option A — Install script (recommended)
+### Option A — npm (recommended, no clone)
+
+If you have Node.js (≥18), install and enable all 15 plugins with a single
+command — no `git clone` and no Python required. The installer copies each
+plugin into your Claude Code plugin cache and enables them in `settings.json`,
+then you restart Claude Code:
+
+```bash
+npx @chuanseng-ng/digital-chip-design-agents
+```
+
+Re-run the same command to pick up future updates. Works identically on macOS,
+Linux, and Windows (a single Node process copies plugins sequentially, so there
+is no concurrent-write contention on the cache directory). This currently
+installs the Claude Code plugins only; for other IDEs use Option D below.
+
+### Option B — Install script
 
 Clone the repo and run one script — all 15 plugins are installed and enabled in a
 single step, no repeated commands needed.
@@ -30,7 +46,7 @@ cd digital-chip-design-agents
 
 Restart Claude Code after running — all 16 skills and 15 agents will be active.
 
-### Option B — Marketplace (selective install)
+### Option C — Marketplace (selective install)
 
 If you only need specific domains, install them individually via the Claude Code
 marketplace. First register the marketplace, then install the domains you need:
@@ -60,7 +76,7 @@ marketplace. First register the marketplace, then install the domains you need:
 
 </details>
 
-### Option C — Other AI assistants (Copilot / Gemini / OpenCode / Codex CLI)
+### Option D — Other AI assistants (Copilot / Gemini / OpenCode / Codex CLI)
 
 Run the install script from your chip design project directory with `--ide`:
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// install.mjs — installs digital-chip-design-agents plugins for Claude Code.
+//
+// Usage (via npm):
+//   npx @chuanseng-ng/digital-chip-design-agents            # Claude Code (default)
+//   npx @chuanseng-ng/digital-chip-design-agents --ide claude
+//
+// This is the cross-platform Node port of the Claude Code path of install.sh.
+// It runs as a single process and copies each plugin sequentially, so there is
+// no concurrent write contention to the shared cache directory — the file-lock
+// race that affected parallel marketplace installs on Windows cannot occur here.
+//
+// The other IDE targets (copilot, gemini, opencode, codex) are not yet ported
+// to Node; use install.sh / install.ps1 for those. The shell scripts remain the
+// supported fallback when Node is unavailable.
+
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, cpSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MARKETPLACE = "digital-chip-design-agents";
+
+// Package root = parent of this bin/ directory. Resolving from import.meta.url
+// (not process.cwd) makes the installer work from npm's unpacked layout.
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+// ── Parse flags ───────────────────────────────────────────────────────────────
+let ide = "claude";
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  if (arg === "--ide") {
+    ide = argv[++i];
+  } else if (arg === "--global") {
+    // accepted for flag-parity with install.sh; only affects non-claude IDEs
+  } else if (arg === "-h" || arg === "--help") {
+    console.log("Usage: npx @chuanseng-ng/digital-chip-design-agents [--ide claude]");
+    process.exit(0);
+  } else {
+    fail(`Unknown argument: ${arg}\nUsage: npx @chuanseng-ng/digital-chip-design-agents [--ide claude]`);
+  }
+}
+
+const VALID_IDES = ["claude", "copilot", "gemini", "opencode", "codex", "all"];
+if (!VALID_IDES.includes(ide)) {
+  fail(`--ide must be one of: ${VALID_IDES.join(", ")}`);
+}
+
+if (ide !== "claude") {
+  console.log(
+    `The npm installer currently supports only --ide claude.\n` +
+      `For "${ide}", run the shell installer from a cloned repo:\n` +
+      `  bash install.sh --ide ${ide}      (macOS/Linux/Git Bash)\n` +
+      `  .\\install.ps1 -IDE ${ide}         (Windows PowerShell)`
+  );
+  if (ide !== "all") process.exit(0);
+  // for "all", continue with the Claude Code portion below.
+}
+
+// ── Load plugin list from the marketplace manifest (single source of truth) ────
+const marketplacePath = join(PACKAGE_ROOT, ".claude-plugin", "marketplace.json");
+if (!existsSync(marketplacePath)) {
+  fail(`Cannot locate ${marketplacePath}. The package appears to be incomplete.`);
+}
+const plugins = readJson(marketplacePath).plugins;
+
+// ── Locate the Claude config directory ─────────────────────────────────────────
+// os.homedir() resolves %USERPROFILE% on Windows and $HOME elsewhere, matching
+// install.sh's per-platform handling without needing a shell.
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+const cacheDir = join(claudeDir, "plugins", "cache", MARKETPLACE);
+const settingsPath = join(claudeDir, "settings.json");
+
+console.log(`Claude config : ${claudeDir}`);
+console.log(`Plugin cache  : ${cacheDir}`);
+console.log("");
+
+if (!existsSync(claudeDir)) {
+  fail(
+    `Claude config directory not found at ${claudeDir}\n` +
+      `  Make sure Claude Code is installed and has been run at least once.`
+  );
+}
+
+// ── Copy each plugin into its own versioned cache directory ────────────────────
+console.log("Installing Claude Code plugin cache...");
+for (const plugin of plugins) {
+  const name = plugin.name;
+  const src = resolve(PACKAGE_ROOT, plugin.source);
+
+  // Each plugin installs under the version declared in its own plugin.json, so
+  // plugins at different versions (e.g. meta at 1.0.0 vs the rest at 1.2.0) land
+  // in the correct cache path. Falls back to the package version if absent.
+  const manifestPath = join(src, ".claude-plugin", "plugin.json");
+  const version = existsSync(manifestPath)
+    ? readJson(manifestPath).version
+    : readJson(join(PACKAGE_ROOT, "package.json")).version;
+
+  const dest = join(cacheDir, name, version);
+  rmSync(dest, { recursive: true, force: true });
+  mkdirSync(dest, { recursive: true });
+
+  for (const sub of ["agents", "skills", ".claude-plugin"]) {
+    const from = join(src, sub);
+    if (existsSync(from)) cpSync(from, join(dest, sub), { recursive: true });
+  }
+  for (const file of ["README.md", "LICENSE"]) {
+    const from = join(PACKAGE_ROOT, file);
+    if (existsSync(from)) cpSync(from, join(dest, file));
+  }
+
+  console.log(`  [OK] ${name}`);
+}
+
+// ── Register plugins in settings.json (read-merge-write, replaces the Python) ───
+console.log("");
+console.log(`Updating ${settingsPath} ...`);
+
+const cfg = existsSync(settingsPath) ? readJson(settingsPath) : {};
+const enabled = (cfg.enabledPlugins ??= {});
+for (const plugin of plugins) {
+  enabled[`${plugin.name}@${MARKETPLACE}`] = true;
+}
+const marketplaces = (cfg.extraKnownMarketplaces ??= {});
+marketplaces[MARKETPLACE] = {
+  source: { source: "directory", path: PACKAGE_ROOT },
+};
+
+writeFileSync(settingsPath, JSON.stringify(cfg, null, 2) + "\n");
+console.log(`  [OK] ${plugins.length} plugins enabled in settings.json`);
+
+console.log("");
+console.log(`Done! Restart Claude Code to activate all ${plugins.length} plugins.`);

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -2,8 +2,8 @@
 // install.mjs — installs digital-chip-design-agents plugins for Claude Code.
 //
 // Usage (via npm):
-//   npx @chuanseng-ng/digital-chip-design-agents            # Claude Code (default)
-//   npx @chuanseng-ng/digital-chip-design-agents --ide claude
+//   npx digital-chip-design-agents            # Claude Code (default)
+//   npx digital-chip-design-agents --ide claude
 //
 // This is the cross-platform Node port of the Claude Code path of install.sh.
 // It runs as a single process and copies each plugin sequentially, so there is
@@ -44,10 +44,10 @@ for (let i = 0; i < argv.length; i++) {
   } else if (arg === "--global") {
     // accepted for flag-parity with install.sh; only affects non-claude IDEs
   } else if (arg === "-h" || arg === "--help") {
-    console.log("Usage: npx @chuanseng-ng/digital-chip-design-agents [--ide claude]");
+    console.log("Usage: npx digital-chip-design-agents [--ide claude]");
     process.exit(0);
   } else {
-    fail(`Unknown argument: ${arg}\nUsage: npx @chuanseng-ng/digital-chip-design-agents [--ide claude]`);
+    fail(`Unknown argument: ${arg}\nUsage: npx digital-chip-design-agents [--ide claude]`);
   }
 }
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -79,6 +79,10 @@ const plugins = readJson(marketplacePath).plugins;
 // install.sh's per-platform handling without needing a shell.
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
 const cacheDir = join(claudeDir, "plugins", "cache", MARKETPLACE);
+// Durable copy of the marketplace source. Claude Code needs source.path to stay
+// valid for catalog refresh and updates, so we copy the payload under claudeDir
+// rather than pointing at the npm/npx package dir, which is reclaimable.
+const installRoot = join(claudeDir, "plugins", "marketplaces", MARKETPLACE);
 const settingsPath = join(claudeDir, "settings.json");
 
 console.log(`Claude config : ${claudeDir}`);
@@ -122,6 +126,20 @@ for (const plugin of plugins) {
   console.log(`  [OK] ${name}`);
 }
 
+// ── Copy the marketplace source to a durable location under claudeDir ───────────
+// This is what settings.json points at, so marketplace refresh/updates keep
+// working even after the (reclaimable) npm/npx package directory is cleaned up.
+rmSync(installRoot, { recursive: true, force: true });
+mkdirSync(installRoot, { recursive: true });
+for (const sub of [".claude-plugin", "plugins"]) {
+  const from = join(PACKAGE_ROOT, sub);
+  if (existsSync(from)) cpSync(from, join(installRoot, sub), { recursive: true });
+}
+for (const file of ["README.md", "LICENSE"]) {
+  const from = join(PACKAGE_ROOT, file);
+  if (existsSync(from)) cpSync(from, join(installRoot, file));
+}
+
 // ── Register plugins in settings.json (read-merge-write, replaces the Python) ───
 console.log("");
 console.log(`Updating ${settingsPath} ...`);
@@ -133,7 +151,7 @@ for (const plugin of plugins) {
 }
 const marketplaces = (cfg.extraKnownMarketplaces ??= {});
 marketplaces[MARKETPLACE] = {
-  source: { source: "directory", path: PACKAGE_ROOT },
+  source: { source: "directory", path: installRoot },
 };
 
 writeFileSync(settingsPath, JSON.stringify(cfg, null, 2) + "\n");

--- a/install.ps1
+++ b/install.ps1
@@ -24,7 +24,8 @@ $ErrorActionPreference = "Stop"
 
 $RepoDir     = $PSScriptRoot
 $Marketplace = "digital-chip-design-agents"
-$Version     = "1.0.0"
+# Each plugin's cache version is read from its own .claude-plugin\plugin.json
+# below, so plugins at different versions land in the correct path.
 
 # ── Locate python3 ────────────────────────────────────────────────────────────
 $Python = "python3"
@@ -51,7 +52,8 @@ $Plugins = @(
     "chip-design-sta",           "chip-design-hls",
     "chip-design-pd",            "chip-design-soc",
     "chip-design-compiler",      "chip-design-firmware",
-    "chip-design-fpga",          "chip-design-infrastructure"
+    "chip-design-fpga",          "chip-design-infrastructure",
+    "chip-design-meta"
 )
 
 $PluginDirs = @{
@@ -69,6 +71,7 @@ $PluginDirs = @{
     "chip-design-firmware"       = "firmware"
     "chip-design-fpga"           = "fpga"
     "chip-design-infrastructure" = "infrastructure"
+    "chip-design-meta"           = "meta"
 }
 
 # Helper: run a Python script stored in a temp file, then clean up
@@ -108,6 +111,9 @@ if ($IDE -eq "claude" -or $IDE -eq "all") {
     foreach ($Plugin in $Plugins) {
         $Subdir = $PluginDirs[$Plugin]
         $Src    = Join-Path $RepoDir "plugins\$Subdir"
+        $PluginJson = Join-Path $Src ".claude-plugin\plugin.json"
+        $Version = & $Python -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" $PluginJson
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version from $PluginJson" }
         $Dest   = Join-Path $CacheDir "$Plugin\$Version"
 
         if (Test-Path $Dest) { Remove-Item $Dest -Recurse -Force }
@@ -140,6 +146,7 @@ plugins = [
   "chip-design-sta",          "chip-design-hls",       "chip-design-pd",
   "chip-design-soc",          "chip-design-compiler",  "chip-design-firmware",
   "chip-design-fpga",         "chip-design-infrastructure",
+  "chip-design-meta",
 ]
 
 cfg = {}
@@ -165,7 +172,7 @@ print(f"  [OK] {len(plugins)} plugins enabled in settings.json")
     Invoke-PythonScript -ScriptContent $SettingsPy -Args @($Settings, $Marketplace, $RepoDir)
 
     Write-Host ""
-    Write-Host "Done! Restart Claude Code to activate all 14 plugins."
+    Write-Host "Done! Restart Claude Code to activate all 15 plugins."
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MARKETPLACE="digital-chip-design-agents"
-VERSION="1.0.0"
+# Each plugin's cache version is read from its own .claude-plugin/plugin.json
+# below, so plugins at different versions land in the correct path.
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 IDE="claude"
@@ -74,6 +75,7 @@ PLUGINS=(
   "chip-design-firmware"
   "chip-design-fpga"
   "chip-design-infrastructure"
+  "chip-design-meta"
 )
 
 # ── Plugin → source directory mapping ────────────────────────────────────────
@@ -92,6 +94,7 @@ declare -A PLUGIN_DIRS=(
   ["chip-design-firmware"]="firmware"
   ["chip-design-fpga"]="fpga"
   ["chip-design-infrastructure"]="infrastructure"
+  ["chip-design-meta"]="meta"
 )
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -125,7 +128,8 @@ if [[ "$IDE" == "claude" || "$IDE" == "all" ]]; then
   for plugin in "${PLUGINS[@]}"; do
     subdir="${PLUGIN_DIRS[$plugin]}"
     src="$REPO_DIR/plugins/$subdir"
-    dest="$CACHE_DIR/$plugin/$VERSION"
+    version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$src/.claude-plugin/plugin.json")"
+    dest="$CACHE_DIR/$plugin/$version"
     rm -rf "$dest"
     mkdir -p "$dest"
     cp -r "$src/agents"         "$dest/"
@@ -151,6 +155,7 @@ plugins = [
   "chip-design-sta",          "chip-design-hls",       "chip-design-pd",
   "chip-design-soc",          "chip-design-compiler",  "chip-design-firmware",
   "chip-design-fpga",         "chip-design-infrastructure",
+  "chip-design-meta",
 ]
 
 cfg = {}
@@ -175,7 +180,7 @@ print(f"  [OK] {len(plugins)} plugins enabled in settings.json")
 PYEOF
 
   echo ""
-  echo "Done! Restart Claude Code to activate all 14 plugins."
+  echo "Done! Restart Claude Code to activate all 15 plugins."
 
 fi  # end Claude Code block
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chuanseng-ng/digital-chip-design-agents",
+  "name": "digital-chip-design-agents",
   "version": "1.3.0",
   "description": "Full digital chip design pipeline — 15 Claude Code plugins across 14 domains, from infrastructure setup through tape-out and firmware, with closed-loop verification↔RTL feedback.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@chuanseng-ng/digital-chip-design-agents",
+  "version": "1.3.0",
+  "description": "Full digital chip design pipeline — 15 Claude Code plugins across 14 domains, from infrastructure setup through tape-out and firmware, with closed-loop verification↔RTL feedback.",
+  "type": "module",
+  "bin": {
+    "digital-chip-design-agents": "bin/install.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/",
+    "plugins/",
+    "ides/",
+    ".claude-plugin/",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "chip-design",
+    "asic",
+    "fpga",
+    "rtl",
+    "verilog",
+    "systemverilog",
+    "eda",
+    "vlsi",
+    "agents"
+  ],
+  "homepage": "https://github.com/chuanseng-ng/digital-chip-design-agents#readme",
+  "bugs": {
+    "url": "https://github.com/chuanseng-ng/digital-chip-design-agents/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chuanseng-ng/digital-chip-design-agents.git"
+  },
+  "author": {
+    "name": "chuanseng-ng",
+    "url": "https://github.com/chuanseng-ng"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
Publish the plugin collection to npm so users can install all 15 Claude
Code plugins with `npx @chuanseng-ng/digital-chip-design-agents` — no git
clone and no Python required.

The Node installer runs as a single process and copies each plugin
sequentially into the Claude cache, so the concurrent-write contention that
affected parallel marketplace installs on Windows cannot occur. It is the
cross-platform port of the Claude Code path of install.sh: it reads the
plugin list from marketplace.json, installs each plugin under the version
declared in its own plugin.json, and merges settings.json natively.

- package.json: scoped package, bin entry, files whitelist (excludes
  memory/, docs/, root tools/), Node >=18
- bin/install.mjs: marketplace-driven, per-plugin-versioned installer
- README: new "Option A — npm" section, renumber remaining options
- install.sh / install.ps1: add chip-design-meta (was missing — only 14 of
  15 plugins installed) and read each plugin's version from plugin.json
  instead of a stale hardcoded 1.0.0, so all three install paths now produce
  an identical cache layout
- release.yml: guarded npm-publish job (runs only when NPM_TOKEN is set),
  stamps the tag version into package.json and all manifests before publish

https://claude.ai/code/session_01QU2na7S4Vbf8hFVBk9rNx3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform CLI to install and enable the marketplace; enables 15 plugins including chip-design-meta.

* **Documentation**
  * Installation section reorganized and renumbered with clearer options, restart guidance, and selective install instructions.

* **Chores**
  * Optional automated npm publish step (runs when publish token is present).
  * CI/release actions pinned for reproducibility; package manifest and Dependabot config added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->