### PR TITLE
fix(release): build archive outside workspace to avoid tar exit-1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,20 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Build release archive
+        id: archive
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          tar -czf digital-chip-design-agents-${VERSION}.tar.gz \
+          ARCHIVE="${RUNNER_TEMP}/digital-chip-design-agents-${VERSION}.tar.gz"
+          # Write the archive outside the repo workspace so tar never sees its
+          # own output file appear inside the directory it is reading (which
+          # triggers "tar: .: file changed as we read it" and an exit-1 failure).
+          tar -czf "$ARCHIVE" \
             --exclude='.git' \
             --exclude='*.tar.gz' \
             .
-          echo "Archive: digital-chip-design-agents-${VERSION}.tar.gz"
-          ls -lh digital-chip-design-agents-${VERSION}.tar.gz
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "Archive: $ARCHIVE"
+          ls -lh "$ARCHIVE"
 
       - name: Generate release notes
         run: |
@@ -96,7 +102,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          files: digital-chip-design-agents-${{ steps.version.outputs.VERSION }}.tar.gz
+          files: ${{ steps.archive.outputs.ARCHIVE }}
           body_path: release_notes.md
           draft: false
           prerelease: ${{ contains(steps.version.outputs.VERSION, 'rc') || contains(steps.version.outputs.VERSION, 'beta') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,9 @@ jobs:
 
       - name: Build release archive
         id: archive
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
           ARCHIVE="${RUNNER_TEMP}/digital-chip-design-agents-${VERSION}.tar.gz"
           # Write the archive outside the repo workspace so tar never sees its
           # own output file appear inside the directory it is reading (which
@@ -60,8 +61,9 @@ jobs:
           ls -lh "$ARCHIVE"
 
       - name: Generate release notes
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
           SKILLS=$(find plugins -name "SKILL.md" | wc -l | tr -d ' ')
           AGENTS=$(find plugins -path "*/agents/*.md" | wc -l | tr -d ' ')
           cat << EOF > release_notes.md


### PR DESCRIPTION
## Problem

The **Tag and Release** job has failed on **every** release tag (verified v1.4.3 → v1.5.6). The `validate` job passes and `npm-publish` is skipped (no `NPM_TOKEN`); the failure is always at the **"Build release archive"** step.

### Root cause

The archive was built with:

```bash
tar -czf digital-chip-design-agents-${VERSION}.tar.gz --exclude='.git' --exclude='*.tar.gz' .
```

tar reads the current directory `.` while writing its output `.tar.gz` **into that same directory**. GNU tar detects the directory changing as it reads, emits `tar: .: file changed as we read it`, and exits with **status 1**. Because the step runs under `bash -e`, that nonzero exit fails the job before it ever reaches "Create GitHub Release". `--exclude='*.tar.gz'` only keeps the file out of the archive contents — it does not stop tar from noticing that `.` was modified when the output file was created.

Log evidence (run 27018840222, tag v1.5.6):
```
Stamped version 1.5.6 into 15 plugin.json files
tar: .: file changed as we read it
##[error]Process completed with exit code 1.
```

## Fix

Write the tarball into `$RUNNER_TEMP` (outside the repo workspace), so tar never sees its own output file appear inside the tree it is reading. The path is exposed via a step output (`id: archive` → `ARCHIVE`) and referenced from the "Create GitHub Release" step's `files:`. The stamped `plugin.json` files (modified in the prior step, all in the working tree) are still captured.

## Verification

- `release.yml` still parses as valid YAML.
- Out-of-tree archive (`tar -czf "$RUNNER_TEMP/..." .`) exits **0**.
- The old in-tree form reproduces `tar: .: file changed as we read it` with **exit 1**.
- Full end-to-end confirmation requires merging to the default branch and pushing a new `vX.Y.Z` tag, since the `Release` workflow only triggers on tags.

https://claude.ai/code/session_011Ekg8N1JrxaEe47Y666Fcn

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ekg8N1JrxaEe47Y666Fcn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release archive is now created in the runner temporary area and its full path is exported for downstream steps.
  * Release notes generation now receives the release version via an environment variable.
  * Release creation uploads the artifact using the archive path output rather than a fixed workspace filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->