### PR TITLE
Migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Full Validation
@@ -14,6 +17,8 @@ jobs:
     name: Tag and Release
     runs-on: ubuntu-latest
     needs: validate
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -115,13 +120,14 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: validate
-    # Only runs when an NPM_TOKEN secret is configured; otherwise it is skipped.
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # Publishes via npm Trusted Publishing (OIDC) — no NPM_TOKEN required.
+    # id-token: write lets npm exchange the GitHub OIDC token for publish access.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
-        if: env.NPM_TOKEN != ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # The publish job only reads, stamps locally, and runs `npm publish` —
@@ -129,19 +135,20 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        if: env.NPM_TOKEN != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm for trusted publishing (OIDC)
+        # Trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
+        run: npm install -g npm@latest
+
       - name: Extract version
-        if: env.NPM_TOKEN != ''
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Stamp tag version into package.json and manifests
-        if: env.NPM_TOKEN != ''
         run: |
           node -e "
           const fs = require('fs');
@@ -159,7 +166,4 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Publish to npm
-        if: env.NPM_TOKEN != ''
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,12 +137,15 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          # This privileged (id-token: write) job only publishes; disable
+          # setup-node's automatic dependency cache to avoid cache poisoning.
+          package-manager-cache: false
 
       - name: Upgrade npm for trusted publishing (OIDC)
-        # Trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
-        run: npm install -g npm@latest
+        # Trusted publishing requires npm >= 11.5.1 on Node >= 22.14.0.
+        run: npm install -g npm@^11.5.1
 
       - name: Extract version
         id: version
@@ -166,4 +169,14 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Publish to npm
-        run: npm publish --access public
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          # Prerelease tags (rc/beta) publish under the "next" dist-tag so they
+          # never overwrite "latest". Mirrors the prerelease check on the
+          # Create GitHub Release step.
+          TAG=latest
+          case "$VERSION" in
+            *rc*|*beta*) TAG=next ;;
+          esac
+          npm publish --access public --tag "$TAG"


### PR DESCRIPTION
## 📌 Description
Migrate the npm publishing workflow from token-based authentication (NPM_TOKEN secret) to OIDC trusted publishing. This improves security by eliminating the need to manage long-lived npm tokens and leverages GitHub's native OIDC provider for temporary, scoped access.

## 🔗 Related Issue
N/A

## 🧪 Type of Change
- [ ] Bug fix
- [x] Improvement / refactor
- [ ] New feature
- [ ] Documentation update

## 🧠 What Changed?
- Added explicit `permissions` block at workflow level with `contents: read`
- Added `permissions` block to "Tag and Release" job with `contents: write`
- Replaced NPM_TOKEN environment variable with OIDC-based permissions (`id-token: write`)
- Removed all conditional `if: env.NPM_TOKEN != ''` checks since publishing now always runs
- Added npm upgrade step to ensure npm >= 11.5.1 (required for OIDC support; Node 20 ships with npm 10.x)
- Removed `NODE_AUTH_TOKEN` secret reference from publish step
- Updated comments to reflect OIDC-based publishing approach

## 🔄 Affected Areas
- [x] Workflow orchestration
- [ ] Agent logic
- [ ] Scripts / tooling
- [ ] Documentation
- [ ] Other

## ⚙️ How to Test
This change requires npm registry configuration to support OIDC. Testing should occur:
1. Verify the workflow runs successfully on a tagged release
2. Confirm npm publish completes without NPM_TOKEN secret
3. Validate that the published package is accessible on npm registry

## 📦 Outputs / Results
- Workflow now uses GitHub OIDC tokens for npm authentication instead of static secrets
- Publishing is no longer conditional on NPM_TOKEN presence
- Improved security posture by eliminating long-lived token management

## ⚠️ Risks / Notes
- Requires npm registry to be configured to accept OIDC tokens from GitHub
- npm must be upgraded to >= 11.5.1 for OIDC support (handled by new upgrade step)
- If npm registry doesn't support OIDC, publishing will fail until configured

## ✅ Checklist
- [x] Changes are scoped and minimal
- [x] No breaking changes (workflow behavior remains the same from user perspective)
- [x] Documentation updated in comments

## 📎 Additional Context
OIDC trusted publishing is the recommended approach for GitHub Actions workflows publishing to npm. This eliminates the security risk of managing long-lived tokens and provides better audit trails through GitHub's native OIDC provider.

https://claude.ai/code/session_014m99Vyi85a75fNUuhdd6Nv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use industry-standard OIDC-based authentication for npm publishing, replacing token-based approach.
  * Enhanced workflow permissions and added version stamping during release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->