### PR TITLE
feat: semantic/keyword experience search with MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased] — feat/semantic-experience-search branch
+
+### Added
+
+- **Semantic / keyword search over experiences** (FUTURE_WORK item 2): a new way for orchestrators to retrieve prior fixes by relevance to a natural-language query (e.g. "what fixed WNS issues on sky130 before?") instead of reading the whole `experiences.jsonl`.
+  - **`tools/experience_search.py`** — core library + standalone CLI. Default backend is a pure-stdlib **TF-IDF + cosine** ranker over the free-text fields (`issues_encountered`, `fixes_applied`, `notes`); reuses the shared `resolve_memory_root`, `load_records`, and `filter_by_design/pdk/tool` helpers so it sees exactly what orchestrators wrote. Returns ranked records with `score`, `matched_terms`, the `backend` used, and a `fell_back`/`fallback_reason` flag. CLI exit codes mirror the repo convention (`0` results, `1` no match, `2` error/bad memory root).
+  - **Optional embedding backend, dormant by default** — `get_embedding_backend()` returns `None` until a deployment wires in an embedding library, keeping the repo stdlib-only. It activates only when a backend is available **and** the domain has ≥ `--min-records` records (default **50**, per the issue threshold); otherwise the tool transparently falls back to keyword. Embeddings cache in a stdlib `sqlite3` index (`<domain>/.experience_index.sqlite3`) keyed by record content hash, with incremental `--reindex`.
+  - **`plugins/infrastructure/tools/mcp-memory.py`** — dedicated MCP stdio server (protocol `2024-11-05`, same scaffolding as `mcp-adapter.py`) exposing the `query_experiences` tool; **`plugins/infrastructure/mcp/mcp-memory.json`** — config template (server name `chip-design-memory`).
+  - **Tests** — `tests/test_experience_search.py` (tokenizer, TF-IDF ranking, filter pre-narrowing, threshold/backend selection, sqlite cache incrementality + stale-hash eviction, CLI exit codes) and `tests/test_mcp_memory.py` (JSON-RPC `initialize`/`tools/list`/`tools/call` smoke + error codes).
+
+### Changed
+
+- **All 15 orchestrators**: added an optional "semantic experience lookup" note to the session-start memory block — call the `query_experiences` MCP tool when available, otherwise proceed with `knowledge.md` only (augments, never replaces). The note is tailored for the router (`pipeline-orchestrator`, queries the target producer domain) and the opt-in `infrastructure-orchestrator`.
+- **`memory/README.md`**: new "Semantic / Keyword Experience Search" section documenting the CLI, the MCP server/config, the threshold/fallback semantics, the sqlite cache + `--reindex`, and the optional orchestrator read-path.
+- **`FUTURE_WORK.md`**: item 2 marked implemented (phased); documented why the sqlite-vec/Chroma/hosted options were rejected in favor of a stdlib-only keyword default with a pluggable embedding hook.
+
 ## [Unreleased] — feat/agent-auto-detect branch
 
 ### Added

--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -16,18 +16,37 @@ into an updated `memory/<domain>/knowledge.md` summary. Implementation includes:
 - Invocable via `/chip-design-infrastructure:memory-keeper --domain <name>` or `--all`
 - Threshold guard: skips domains with fewer than N records (default: 5)
 
-## 2. Semantic Search Over Experiences
+## 2. Semantic Search Over Experiences ✓ IMPLEMENTED (phased)
 
-An MCP memory server that embeds experience records and allows orchestrators to query by similarity
+**Status:** Shipped (phased) — `tools/experience_search.py`,
+`plugins/infrastructure/tools/mcp-memory.py`, and
+`plugins/infrastructure/mcp/mcp-memory.json`.
+
+An MCP memory server (`chip-design-memory`, tool `query_experiences`) that lets
+orchestrators query experience records by similarity
 (e.g., "what fixed WNS issues on sky130 before?") rather than full-file read.
 
-**Prerequisite**: Experience log must be large enough to justify the infrastructure overhead —
-target threshold is ~50 records per domain before semantic search adds value over keyword grep.
+Built **fallback-first** to respect both the deferral (the experience log must be
+large enough to justify embeddings — target ~50 records/domain) and the repo's
+zero-dependency, stdlib-only convention:
 
-Implementation options:
-- SQLite + sqlite-vec extension (zero-dependency, file-based)
-- Chroma or Qdrant (local Docker container)
-- Hosted: Pinecone, Weaviate Cloud
+- **Default keyword backend** — pure-stdlib TF-IDF + cosine over the free-text
+  fields. Adds value at any dataset size; no index or dependency required.
+- **Optional embedding backend** — wired in but dormant; activates only when an
+  embedding library is supplied via `get_embedding_backend()` **and** the domain
+  has ≥ `--min-records` records (default 50). Vectors cache in a stdlib `sqlite3`
+  index keyed by record content hash (incremental re-embedding via `--reindex`).
+  Below the threshold or with no backend, it transparently falls back to keyword
+  and flags `fell_back: true`.
+- All 15 orchestrators carry an optional session-start read-path note that calls
+  the MCP tool when available and otherwise proceeds with `knowledge.md`.
+
+The original options below were **rejected** to preserve the zero-dependency
+convention (no new deps, no native extensions, no external service); a deployment
+that wants true semantic ranking only needs to implement `get_embedding_backend`:
+- ~~SQLite + sqlite-vec extension~~ (sqlite-vec is a native extension, not stdlib)
+- ~~Chroma or Qdrant (local Docker container)~~
+- ~~Hosted: Pinecone, Weaviate Cloud~~
 
 ## 3. Cross-Design Metric Trending ✓ IMPLEMENTED
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -212,3 +212,58 @@ python3 tools/qor_trends.py --design aes_core --pdk sky130 --group-by tool --plo
 
 Regression alerts fire automatically when a metric moves in the wrong direction between
 runs (e.g. WNS degrades, coverage drops).
+
+## Semantic / Keyword Experience Search
+
+`tools/experience_search.py` ranks past experience records by relevance to a
+natural-language query (e.g. *"what fixed WNS issues on sky130 before?"*) so an
+orchestrator can retrieve prior fixes by similarity instead of reading the whole
+JSONL file. It reuses the shared memory-root resolver and the same `load_records`
+/ filter helpers as the other tools, so it sees exactly what the orchestrators
+wrote.
+
+Two backends share one stable contract:
+
+- **keyword** (default, always available) — a pure-stdlib TF-IDF + cosine ranker
+  over the free-text fields (`issues_encountered`, `fixes_applied`, `notes`).
+  Adds value at any dataset size; needs no index or external dependency.
+- **embedding** (optional, dormant) — a pluggable semantic backend that activates
+  only when (a) an embedding library is wired in via `get_embedding_backend()`
+  **and** (b) the domain has at least `--min-records` records (default **50**,
+  per the issue #28 threshold). Vectors are cached in a stdlib `sqlite3` index
+  (`<domain>/.experience_index.sqlite3`) keyed by a content hash, so re-embedding
+  is incremental. Below the threshold (or with no backend), the tool transparently
+  **falls back to keyword** and flags `"backend": "keyword"`, `"fell_back": true`.
+
+```bash
+# Keyword search (works today, any dataset size)
+python3 tools/experience_search.py --domain synthesis \
+  --query "what fixed WNS on sky130" --pdk sky130
+
+# Machine-readable JSON (the MCP server uses this shape)
+python3 tools/experience_search.py --domain synthesis \
+  --query "wns closure" --json
+
+# Warm/refresh the embedding cache once enough records accumulate (no-op
+# until an embedding backend is wired in)
+python3 tools/experience_search.py --domain synthesis --reindex
+```
+
+### MCP memory server
+
+`plugins/infrastructure/tools/mcp-memory.py` exposes the same search as an MCP
+stdio tool, `query_experiences`, following the protocol of the EDA tool adapters
+(MCP `2024-11-05`). Register it from the template at
+`plugins/infrastructure/mcp/mcp-memory.json` (server name `chip-design-memory`)
+by pasting the `mcpServers` block into your `.claude/settings.json` and replacing
+the placeholder repo path.
+
+### Optional orchestrator read-path
+
+When the `query_experiences` MCP tool is available, orchestrators may call it at
+session start — with this `domain`, the current goal/issue as `query`, and known
+`filters` (`pdk`, `tool_used`, `design_name`) — to surface ranked prior fixes.
+This **augments, never replaces**, the `knowledge.md` read: if the tool is
+absent, orchestrators proceed with `knowledge.md` exactly as before (the same
+skip-silently pattern as the optional claude-mem index above). All 15
+orchestrators carry this optional note in their session-start memory block.

--- a/plugins/architecture/agents/architecture-orchestrator.md
+++ b/plugins/architecture/agents/architecture-orchestrator.md
@@ -112,6 +112,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="architecture"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 On any termination path (signoff, escalation, abandonment, interruption, error, or max-turns
 reached), upsert one JSON record in `<MEM>/architecture/experiences.jsonl`. Implement the

--- a/plugins/compiler/agents/compiler-orchestrator.md
+++ b/plugins/compiler/agents/compiler-orchestrator.md
@@ -84,6 +84,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="compiler"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `<MEM>/compiler/experiences.jsonl`:

--- a/plugins/dft/agents/dft-orchestrator.md
+++ b/plugins/dft/agents/dft-orchestrator.md
@@ -89,6 +89,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="dft"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/dft/experiences.jsonl`:

--- a/plugins/firmware/agents/firmware-orchestrator.md
+++ b/plugins/firmware/agents/firmware-orchestrator.md
@@ -84,6 +84,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="firmware"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/firmware/experiences.jsonl`:

--- a/plugins/formal/agents/formal-orchestrator.md
+++ b/plugins/formal/agents/formal-orchestrator.md
@@ -92,6 +92,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="formal"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `<MEM>/formal/experiences.jsonl`:

--- a/plugins/fpga/agents/fpga-orchestrator.md
+++ b/plugins/fpga/agents/fpga-orchestrator.md
@@ -96,6 +96,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="fpga"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/fpga/experiences.jsonl`:

--- a/plugins/hls/agents/hls-orchestrator.md
+++ b/plugins/hls/agents/hls-orchestrator.md
@@ -93,6 +93,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="hls"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), upsert (create or replace by `run_id`) one JSON line in
 `<MEM>/hls/experiences.jsonl`:

--- a/plugins/infrastructure/agents/infrastructure-orchestrator.md
+++ b/plugins/infrastructure/agents/infrastructure-orchestrator.md
@@ -193,6 +193,9 @@ Read `<MEM>/infrastructure/knowledge.md` for known setup quirks and version-mism
 prefer entries whose environment fingerprint matches the current host. Read
 `<MEM>/infrastructure/run_state.md` if resuming an interrupted setup.
 
+
+**Optional — semantic experience lookup.** When infrastructure memory is enabled and the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, call it with `domain="infrastructure"` and the current setup issue as `query` to retrieve prior tool/version fixes; prefer results whose environment matches the current host. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, it.
+
 ### Write (after `environment_validation`, if enabled)
 Upsert one record (create-or-replace by `run_id`) into `<MEM>/infrastructure/experiences.jsonl`
 using the atomic read-modify-write protocol in `memory/README.md`. Records are

--- a/plugins/infrastructure/mcp/mcp-memory.json
+++ b/plugins/infrastructure/mcp/mcp-memory.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Experience semantic/keyword search MCP server — paste the mcpServers block into your .claude/settings.json. Replace /absolute/path/to with the actual repo root path. Optionally pass --memory-root to pin a memory location; default auto-detects via memory_root.py ($CHIP_DESIGN_MEMORY_ROOT > central XDG > in-repo seed).",
+  "mcpServers": {
+    "chip-design-memory": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/plugins/infrastructure/tools/mcp-memory.py"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/plugins/infrastructure/tools/mcp-memory.py
+++ b/plugins/infrastructure/tools/mcp-memory.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+mcp-memory.py — MCP stdio server exposing semantic/keyword experience search.
+
+Implements MCP protocol version 2024-11-05 over stdio (JSON-RPC 2.0,
+newline-delimited), mirroring the protocol scaffolding of ``mcp-adapter.py``.
+Unlike the tool adapter, this server does its work in-process by importing
+``tools/experience_search.py`` rather than spawning a shell wrapper.
+
+Exposes a single tool, ``query_experiences``, that ranks past experience
+records in ``memory/<domain>/experiences.jsonl`` by relevance to a query and
+returns a compact JSON result (ranked records + score + matched terms + which
+backend ran + whether it fell back to keyword search).
+
+Usage:
+    python3 mcp-memory.py [--memory-root PATH] [--version 1.0.0]
+
+All debug/status output goes to stderr so it never corrupts the MCP protocol
+stream on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# tools/experience_search.py is the source of truth for ranking + the memory
+# root resolver. plugins/infrastructure/tools/mcp-memory.py -> repo root is parents[3].
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SEARCH_PATH = REPO_ROOT / "tools" / "experience_search.py"
+
+_spec = importlib.util.spec_from_file_location("experience_search", _SEARCH_PATH)
+experience_search = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(experience_search)
+
+
+# ---------------------------------------------------------------------------
+# MCP protocol helpers (same shape as mcp-adapter.py)
+# ---------------------------------------------------------------------------
+
+def _send(msg: dict) -> None:
+    sys.stdout.write(json.dumps(msg, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def _ok(req_id, result: dict) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _err(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+TOOL_NAME = "query_experiences"
+
+
+def _input_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "enum": list(experience_search.VALID_DOMAINS),
+                "description": "Domain to search (e.g. synthesis, pd, sta)",
+            },
+            "query": {
+                "type": "string",
+                "description": "Natural-language query, e.g. 'what fixed WNS on sky130'",
+            },
+            "filters": {
+                "type": "object",
+                "description": "Optional exact-match pre-filters",
+                "properties": {
+                    "design_name": {"type": "string"},
+                    "pdk": {"type": "string"},
+                    "tool_used": {"type": "string"},
+                },
+            },
+            "limit": {"type": "integer", "default": 5,
+                      "description": "Max results to return"},
+            "min_records_threshold": {
+                "type": "integer", "default": 50,
+                "description": "Below this domain record count, embedding falls back to keyword",
+            },
+            "backend": {
+                "type": "string",
+                "enum": ["auto", "keyword", "embedding"],
+                "default": "auto",
+            },
+        },
+        "required": ["domain", "query"],
+    }
+
+
+def _handle_call(arguments: dict, memory_root: str | None) -> dict:
+    domain = arguments.get("domain", "")
+    query = arguments.get("query", "")
+    if domain not in experience_search.VALID_DOMAINS:
+        return {"error": f"unknown domain {domain!r}",
+                "valid_domains": list(experience_search.VALID_DOMAINS)}
+    if not isinstance(query, str) or not query.strip():
+        return {"error": "query must be a non-empty string"}
+
+    raw_filters = arguments.get("filters") or {}
+    filters = {k: raw_filters[k] for k in ("design_name", "pdk", "tool_used")
+               if isinstance(raw_filters, dict) and raw_filters.get(k)}
+
+    return experience_search.query_experiences(
+        domain, query,
+        filters=filters,
+        limit=int(arguments.get("limit", 5)),
+        min_records_threshold=int(arguments.get("min_records_threshold", 50)),
+        memory_root=memory_root,
+        backend=arguments.get("backend", "auto"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main server loop
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="MCP stdio server for experience semantic/keyword search")
+    parser.add_argument("--memory-root", default=None,
+                        help="Explicit memory root (default: auto-detect)")
+    parser.add_argument("--version", default="1.0.0")
+    args = parser.parse_args()
+
+    description = (
+        "Search past chip-design experience records by similarity; returns "
+        "ranked prior fixes with scores, matched terms, and the backend used")
+
+    print(f"[mcp-memory] starting (memory_root={args.memory_root or 'auto'})",
+          file=sys.stderr)
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        try:
+            req = json.loads(raw_line)
+        except json.JSONDecodeError:
+            print(f"[mcp-memory] malformed JSON ignored: {raw_line[:100]}",
+                  file=sys.stderr)
+            continue
+
+        method: str = req.get("method", "")
+        req_id = req.get("id")
+        _raw_params = req.get("params")
+        params: dict = _raw_params if isinstance(_raw_params, dict) else {}
+
+        if req_id is None:
+            print(f"[mcp-memory] notification: {method}", file=sys.stderr)
+            continue
+
+        print(f"[mcp-memory] request id={req_id} method={method}", file=sys.stderr)
+
+        if method == "initialize":
+            _send(_ok(req_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "memory-mcp", "version": args.version},
+            }))
+
+        elif method == "ping":
+            _send(_ok(req_id, {}))
+
+        elif method == "tools/list":
+            _send(_ok(req_id, {
+                "tools": [{
+                    "name": TOOL_NAME,
+                    "description": description,
+                    "inputSchema": _input_schema(),
+                }]
+            }))
+
+        elif method == "tools/call":
+            call_name: str = params.get("name", "")
+            _raw_args = params.get("arguments")
+            if _raw_args is not None and not isinstance(_raw_args, dict):
+                _send(_err(req_id, -32602, "Invalid params: 'arguments' must be an object"))
+                continue
+            call_inputs: dict = _raw_args if isinstance(_raw_args, dict) else {}
+
+            if call_name != TOOL_NAME:
+                _send(_err(req_id, -32602,
+                           f"Unknown tool '{call_name}'; this server exposes '{TOOL_NAME}'"))
+                continue
+
+            try:
+                result = _handle_call(call_inputs, args.memory_root)
+            except Exception as exc:  # noqa: BLE001
+                _send(_ok(req_id, {
+                    "content": [{"type": "text",
+                                 "text": json.dumps({"error": str(exc)})}],
+                    "isError": True,
+                }))
+                continue
+
+            _send(_ok(req_id, {
+                "content": [{"type": "text", "text": json.dumps(result, indent=2)}],
+                "isError": "error" in result,
+            }))
+
+        else:
+            _send(_err(req_id, -32601, f"Method not found: {method}"))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/meta/agents/pipeline-orchestrator.md
+++ b/plugins/meta/agents/pipeline-orchestrator.md
@@ -140,6 +140,9 @@ Before beginning `detect_open_fix_requests`, read `<MEM>/meta/knowledge.md` if i
 Use it for iteration-cap heuristics and escalation-message templates.
 If the file does not exist, proceed without it.
 
+
+**Optional — semantic experience lookup.** Before dispatching a fix to a producer domain, if the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, call it with `domain` set to the target producer domain (e.g. `"rtl-design"`), the open `fix_request` summary as `query`, and known `filters` (`pdk`, `tool_used`, `design_name`). Pass the ranked prior fixes to the dispatched orchestrator as additional context. The result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. Skip silently if the tool is unavailable.
+
 ### Write (session end)
 Upsert one JSON line in `<MEM>/meta/experiences.jsonl`:
 ```json

--- a/plugins/pd/agents/physical-design-orchestrator.md
+++ b/plugins/pd/agents/physical-design-orchestrator.md
@@ -105,6 +105,9 @@ Before beginning `floorplan`, read the following if they exist:
 - `<MEM>/pd/run_state.md` — if present, a prior run was interrupted; use the
   `run_id` and `last_stage` fields to resume correctly.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="pd"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write: run state (first action, before any tool invocation)
 Write `<MEM>/pd/run_state.md`:
 ```markdown

--- a/plugins/rtl-design/agents/rtl-design-orchestrator.md
+++ b/plugins/rtl-design/agents/rtl-design-orchestrator.md
@@ -95,6 +95,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="rtl-design"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/rtl-design/experiences.jsonl`:

--- a/plugins/soc/agents/soc-integration-orchestrator.md
+++ b/plugins/soc/agents/soc-integration-orchestrator.md
@@ -93,6 +93,9 @@ successful tool flags, and PDK-specific notes. If the file does not exist, proce
 without it. Also initialise `state.run_id` to `soc_<YYYYMMDD>_<HHMMSS>` at this
 point; all subsequent stage writes and upsert operations must reference this value.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="soc"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 On any termination path (signoff, escalation, abandon, interruption, error, or max-turns), upsert
 (create or replace by `run_id`) one JSON line in `<MEM>/soc/experiences.jsonl` immediately with

--- a/plugins/sta/agents/sta-orchestrator.md
+++ b/plugins/sta/agents/sta-orchestrator.md
@@ -99,6 +99,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="sta"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/sta/experiences.jsonl`:

--- a/plugins/synthesis/agents/synthesis-orchestrator.md
+++ b/plugins/synthesis/agents/synthesis-orchestrator.md
@@ -89,6 +89,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="synthesis"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/synthesis/experiences.jsonl`:

--- a/plugins/verification/agents/verification-orchestrator.md
+++ b/plugins/verification/agents/verification-orchestrator.md
@@ -93,6 +93,9 @@ Incorporate its guidance into stage decisions — especially known failure patte
 successful tool flags, and PDK-specific notes. If the file does not exist, proceed
 without it.
 
+
+**Optional — semantic experience lookup.** If the `query_experiences` MCP tool (from the `chip-design-memory` server) is available, before the first stage call it with `domain="verification"`, the current goal or failing-stage issue as `query`, and any known `filters` (`pdk`, `tool_used`, `design_name`). Use the ranked prior fixes to inform stage decisions; the result's `backend`/`fell_back` flags indicate whether ranking was semantic or keyword. If the tool is unavailable, proceed with `knowledge.md` only — this augments, never replaces, the `knowledge.md` read.
+
 ### Write (session end)
 After signoff (or on escalation/abandon), append one JSON line to
 `<MEM>/verification/experiences.jsonl`:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,12 @@ def distill():
     return _load("distill", "plugins/infrastructure/skills/memory-keeper/distill.py")
 
 
+@pytest.fixture
+def experience_search():
+    # Function-scoped so tests may monkeypatch get_embedding_backend in isolation.
+    return _load("experience_search", "tools/experience_search.py")
+
+
 @pytest.fixture(scope="session")
 def fixtures_dir() -> Path:
     return FIXTURES

--- a/tests/test_experience_search.py
+++ b/tests/test_experience_search.py
@@ -1,0 +1,265 @@
+"""Unit + CLI tests for tools/experience_search.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from conftest import write_experiences
+
+SEARCH = Path(__file__).resolve().parents[1] / "tools/experience_search.py"
+
+
+# ---------------------------------------------------------------------------
+# Text processing
+# ---------------------------------------------------------------------------
+
+def test_tokenize_keeps_eda_tokens_and_strips_stopwords(experience_search):
+    toks = experience_search.tokenize("What fixed the WNS_ns on sky130 with -flatten before?")
+    assert "wns_ns" in toks
+    assert "sky130" in toks
+    assert "-flatten" in toks
+    assert "fixed" in toks
+    # stopwords gone
+    for sw in ("what", "the", "on", "with", "before"):
+        assert sw not in toks
+
+
+def test_searchable_text_joins_freetext_fields(experience_search):
+    rec = {
+        "issues_encountered": ["wns -0.35ns on critical path"],
+        "fixes_applied": ["upsized drivers; set_max_fanout 8"],
+        "notes": "sky130 corner",
+    }
+    text = experience_search.searchable_text(rec)
+    assert "wns" in text and "drivers" in text and "sky130" in text
+
+
+# ---------------------------------------------------------------------------
+# Keyword ranking
+# ---------------------------------------------------------------------------
+
+def _records():
+    return [
+        {
+            "run_id": "synthesis_1", "timestamp": "2026-01-01T00:00:00Z",
+            "design_name": "demo_cpu", "pdk": "sky130", "tool_used": "yosys",
+            "key_metrics": {"wns_ns": -0.35},
+            "issues_encountered": ["wns -0.35ns on critical path"],
+            "fixes_applied": ["upsized drivers to close wns on sky130"],
+            "notes": "sky130 timing closure",
+        },
+        {
+            "run_id": "synthesis_2", "timestamp": "2026-01-02T00:00:00Z",
+            "design_name": "demo_cpu", "pdk": "gf180mcu", "tool_used": "yosys",
+            "key_metrics": {"area_um2": 45000},
+            "issues_encountered": ["area over budget"],
+            "fixes_applied": ["enabled area recovery pass"],
+            "notes": "gf180mcu area work",
+        },
+    ]
+
+
+def test_keyword_ranks_relevant_record_first(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.query_experiences(
+        "synthesis", "what fixed wns on sky130",
+        memory_root=mem, backend="keyword")
+    assert out["backend"] == "keyword"
+    assert out["fell_back"] is False
+    assert out["results"], "expected at least one match"
+    assert out["results"][0]["run_id"] == "synthesis_1"
+    assert "wns" in out["results"][0]["matched_terms"]
+
+
+def test_filters_pre_narrow_candidates(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.query_experiences(
+        "synthesis", "wns area",
+        filters={"pdk": "sky130"}, memory_root=mem, backend="keyword")
+    assert out["candidates_after_filter"] == 1
+    assert out["filters_applied"] == {"pdk": "sky130"}
+    for r in out["results"]:
+        assert r["pdk"] == "sky130"
+
+
+def test_no_matching_records_returns_empty(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.query_experiences(
+        "synthesis", "completely unrelated zzzqqq",
+        memory_root=mem, backend="keyword")
+    assert out["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# Backend selection / threshold fallback
+# ---------------------------------------------------------------------------
+
+def test_select_backend_truth_table(experience_search):
+    sb = experience_search._select_backend
+    # explicit keyword: never falls back, no reason
+    assert sb("keyword", 100, 50, True) == ("keyword", None)
+    # auto, available + above threshold -> embedding
+    assert sb("auto", 50, 50, True) == ("embedding", None)
+    # auto, available but below threshold -> keyword + reason
+    resolved, reason = sb("auto", 10, 50, True)
+    assert resolved == "keyword" and "threshold" in reason
+    # auto, unavailable -> keyword + reason
+    resolved, reason = sb("auto", 100, 50, False)
+    assert resolved == "keyword" and "unavailable" in reason
+    # embedding requested, unavailable -> keyword + reason
+    resolved, reason = sb("embedding", 100, 50, False)
+    assert resolved == "keyword" and "unavailable" in reason
+
+
+def test_auto_falls_back_to_keyword_below_threshold(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.query_experiences(
+        "synthesis", "wns sky130", memory_root=mem,
+        backend="auto", min_records_threshold=50)
+    assert out["backend"] == "keyword"
+    assert out["fell_back"] is True
+    assert out["fallback_reason"]
+
+
+def test_embedding_request_without_lib_falls_back(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.query_experiences(
+        "synthesis", "wns sky130", memory_root=mem,
+        backend="embedding", min_records_threshold=1)
+    # No embedding backend wired in by default -> keyword fallback.
+    assert out["backend"] == "keyword"
+    assert out["fell_back"] is True
+    assert "unavailable" in out["fallback_reason"]
+
+
+# ---------------------------------------------------------------------------
+# Embedding cache (with an injected stub backend)
+# ---------------------------------------------------------------------------
+
+def _make_stub(experience_search):
+    class StubBackend(experience_search.EmbeddingBackend):
+        name = "embedding"
+        model = "stub-v1"
+        dim = 4
+
+        def __init__(self):
+            self.calls = 0
+
+        def embed(self, texts):
+            self.calls += len(texts)
+            # Deterministic toy embedding from token hashes.
+            vecs = []
+            for t in texts:
+                toks = experience_search.tokenize(t)
+                v = [0.0, 0.0, 0.0, 0.0]
+                for tok in toks:
+                    v[hash(tok) % 4] += 1.0
+                vecs.append(v)
+            return vecs
+    return StubBackend()
+
+
+def test_embedding_cache_is_incremental(experience_search, tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    stub = _make_stub(experience_search)
+    monkeypatch.setattr(experience_search, "get_embedding_backend", lambda: stub)
+
+    first = experience_search.reindex("synthesis", memory_root=mem)
+    assert first["reindexed"] is True
+    assert first["embedded"] == 2
+    calls_after_first = stub.calls
+
+    # Second reindex with unchanged records embeds nothing new.
+    second = experience_search.reindex("synthesis", memory_root=mem)
+    assert second["embedded"] == 0
+    assert stub.calls == calls_after_first
+
+    # The sqlite index file was created beside the JSONL.
+    assert (mem / "synthesis" / experience_search.INDEX_FILENAME).exists()
+
+
+def test_reindex_drops_stale_hashes(experience_search, tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    stub = _make_stub(experience_search)
+    monkeypatch.setattr(experience_search, "get_embedding_backend", lambda: stub)
+
+    experience_search.reindex("synthesis", memory_root=mem)
+    # Rewrite with only one record -> the other becomes stale.
+    write_experiences(mem, "synthesis", _records()[:1])
+    out = experience_search.reindex("synthesis", memory_root=mem)
+    assert out["removed"] == 1
+    assert out["total"] == 1
+
+
+def test_embedding_backend_used_when_eligible(experience_search, tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    stub = _make_stub(experience_search)
+    monkeypatch.setattr(experience_search, "get_embedding_backend", lambda: stub)
+    out = experience_search.query_experiences(
+        "synthesis", "wns sky130", memory_root=mem,
+        backend="embedding", min_records_threshold=1)
+    assert out["backend"] == "embedding"
+    assert out["fell_back"] is False
+
+
+def test_reindex_no_backend_creates_no_index(experience_search, tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    out = experience_search.reindex("synthesis", memory_root=mem)
+    assert out["reindexed"] is False
+    assert not (mem / "synthesis" / experience_search.INDEX_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(SEARCH), *args], capture_output=True, text=True)
+
+
+def test_cli_json_shape(tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    res = _run("--domain", "synthesis", "--query", "wns sky130",
+               "--memory-root", str(mem), "--json")
+    assert res.returncode == 0, res.stderr
+    data = json.loads(res.stdout)
+    assert data["backend"] == "keyword"
+    assert "results" in data and data["results"]
+
+
+def test_cli_no_records_exits_1(tmp_path):
+    mem = tmp_path / "memory"
+    (mem / "synthesis").mkdir(parents=True)
+    res = _run("--domain", "synthesis", "--query", "anything",
+               "--memory-root", str(mem))
+    assert res.returncode == 1
+
+
+def test_cli_bad_memory_root_exits_2(tmp_path):
+    res = _run("--domain", "synthesis", "--query", "x",
+               "--memory-root", str(tmp_path / "nope"))
+    assert res.returncode == 2
+
+
+def test_cli_reindex_runs(tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    res = _run("--domain", "synthesis", "--reindex", "--memory-root", str(mem))
+    assert res.returncode == 0, res.stderr
+    data = json.loads(res.stdout)
+    # No embedding backend by default -> reindex is a documented no-op.
+    assert data["reindexed"] is False

--- a/tests/test_mcp_memory.py
+++ b/tests/test_mcp_memory.py
@@ -1,0 +1,96 @@
+"""MCP smoke tests for plugins/infrastructure/tools/mcp-memory.py.
+
+Drives the server over stdin with newline-delimited JSON-RPC and asserts the
+responses on stdout, mirroring the MCP protocol shape of mcp-adapter.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from conftest import write_experiences
+
+SERVER = (Path(__file__).resolve().parents[1]
+          / "plugins/infrastructure/tools/mcp-memory.py")
+
+
+def _drive(requests: list[dict], memory_root: str | None = None) -> list[dict]:
+    args = [sys.executable, str(SERVER)]
+    if memory_root:
+        args += ["--memory-root", memory_root]
+    payload = "".join(json.dumps(r) + "\n" for r in requests)
+    proc = subprocess.run(args, input=payload, capture_output=True, text=True)
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _records():
+    return [{
+        "run_id": "synthesis_1", "timestamp": "2026-01-01T00:00:00Z",
+        "design_name": "demo_cpu", "pdk": "sky130", "tool_used": "yosys",
+        "key_metrics": {"wns_ns": -0.35},
+        "issues_encountered": ["wns -0.35ns on critical path"],
+        "fixes_applied": ["upsized drivers to close wns on sky130"],
+        "notes": "sky130 timing closure",
+    }]
+
+
+def test_initialize_reports_protocol_version():
+    resps = _drive([{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}])
+    assert resps[0]["id"] == 1
+    result = resps[0]["result"]
+    assert result["protocolVersion"] == "2024-11-05"
+    assert result["serverInfo"]["name"] == "memory-mcp"
+
+
+def test_tools_list_exposes_query_experiences():
+    resps = _drive([{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}])
+    tools = resps[0]["result"]["tools"]
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool["name"] == "query_experiences"
+    schema = tool["inputSchema"]
+    assert schema["type"] == "object"
+    for key in ("domain", "query", "filters", "limit", "min_records_threshold"):
+        assert key in schema["properties"]
+    assert set(schema["required"]) == {"domain", "query"}
+
+
+def test_tools_call_returns_results(tmp_path):
+    mem = tmp_path / "memory"
+    write_experiences(mem, "synthesis", _records())
+    resps = _drive([{
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": {"name": "query_experiences",
+                   "arguments": {"domain": "synthesis",
+                                 "query": "what fixed wns on sky130"}},
+    }], memory_root=str(mem))
+    result = resps[0]["result"]
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["backend"] == "keyword"
+    assert payload["results"]
+    assert payload["results"][0]["run_id"] == "synthesis_1"
+
+
+def test_unknown_method_returns_minus_32601():
+    resps = _drive([{"jsonrpc": "2.0", "id": 4, "method": "does/not/exist"}])
+    assert resps[0]["error"]["code"] == -32601
+
+
+def test_unknown_tool_returns_minus_32602():
+    resps = _drive([{
+        "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+        "params": {"name": "not_a_tool", "arguments": {}},
+    }])
+    assert resps[0]["error"]["code"] == -32602
+
+
+def test_bad_arguments_type_returns_minus_32602():
+    resps = _drive([{
+        "jsonrpc": "2.0", "id": 6, "method": "tools/call",
+        "params": {"name": "query_experiences", "arguments": "not-an-object"},
+    }])
+    assert resps[0]["error"]["code"] == -32602

--- a/tools/experience_search.py
+++ b/tools/experience_search.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""
+experience_search.py — Semantic / keyword search over agent experience records.
+
+Ranks past experience records in ``memory/<domain>/experiences.jsonl`` by
+relevance to a natural-language query (e.g. "what fixed WNS issues on sky130
+before?") so orchestrators can retrieve prior fixes by similarity instead of
+reading the whole file.
+
+Two backends, one stable contract:
+
+  * keyword  — a pure-stdlib TF-IDF + cosine ranker over the free-text fields
+    (``issues_encountered``, ``fixes_applied``, ``notes``). Always available;
+    adds value at any dataset size. This is the default and the permanent
+    fallback.
+  * embedding — an OPTIONAL semantic backend that activates only when (a) an
+    embedding library is importable AND (b) the domain has at least
+    ``--min-records`` records (default 50, per issue #28). Vectors are cached in
+    a stdlib ``sqlite3`` index keyed by a content hash, so re-embedding is
+    incremental. Dormant by default (stdlib-only repo): ``get_embedding_backend``
+    returns ``None`` until a deployment overrides/monkeypatches it.
+
+The JSON output shape is identical regardless of backend — only the ``backend``
+and ``fell_back`` flags change — so the keyword path is a drop-in for the
+semantic one as records accumulate.
+
+Usage:
+    python3 tools/experience_search.py --domain synthesis \\
+        --query "what fixed WNS on sky130" [options]
+
+Options:
+    --domain DOMAIN          Domain to search (required)
+    --query  TEXT            Natural-language query (required unless --reindex)
+    --design NAME            Filter to records with matching design_name
+    --pdk    VALUE           Filter to records with matching pdk
+    --tool   VALUE           Filter to records with matching tool_used
+    --limit  N               Max results to return (default: 5)
+    --min-records N          Threshold below which embedding falls back to
+                             keyword (default: 50)
+    --backend {auto,keyword,embedding}   Backend selection (default: auto)
+    --memory-root PATH       Path to the memory/ directory (default: auto-detect)
+    --reindex                Rebuild the embedding cache for the domain, then exit
+    --json                   Emit machine-readable JSON (always on for --reindex)
+
+Exit codes:
+    0  — results emitted (or reindex completed)
+    1  — no matching records found
+    2  — unexpected error / bad memory root
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import re
+import sys
+from array import array
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name: str, relpath: str):
+    """Load one of the repo's standalone tool scripts by path (they are run as
+    scripts in production, not installed as a package)."""
+    path = REPO_ROOT / relpath
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Reuse the canonical loaders/filters so this reader agrees with the writers.
+_distill = _load_module(
+    "distill", "plugins/infrastructure/skills/memory-keeper/distill.py")
+_memory_root = _load_module(
+    "memory_root", "plugins/infrastructure/skills/memory-keeper/memory_root.py")
+_qor = _load_module("qor_trends", "tools/qor_trends.py")
+
+VALID_DOMAINS = _distill.VALID_DOMAINS
+load_records = _distill.load_records
+resolve_memory_root = _memory_root.resolve_memory_root
+filter_by_design = _qor.filter_by_design
+filter_by_pdk = _qor.filter_by_pdk
+filter_by_tool = _qor.filter_by_tool
+
+# Free-text fields that carry the searchable signal of an experience record.
+SEARCHABLE_FIELDS = ("issues_encountered", "fixes_applied")
+
+# Small stopword set so natural-language queries ("what fixed WNS issues on
+# sky130 before?") reduce to content terms. Intentionally tiny — over-filtering
+# hurts recall at low record counts.
+STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "with",
+    "was", "were", "is", "are", "be", "been", "did", "do", "does", "what",
+    "which", "how", "when", "where", "why", "before", "after", "this", "that",
+    "these", "those", "from", "by", "at", "as", "it", "its", "we", "i",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9_.\-]+")
+
+# sqlite cache lives beside the JSONL it indexes.
+INDEX_FILENAME = ".experience_index.sqlite3"
+
+
+# ---------------------------------------------------------------------------
+# Text processing
+# ---------------------------------------------------------------------------
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase and split into EDA-friendly tokens.
+
+    Keeps domain tokens like ``wns_ns``, ``sky130``, ``-flatten`` and numbers
+    like ``0.35`` intact; drops stopwords and single characters.
+    """
+    return [
+        t for t in _TOKEN_RE.findall(text.lower())
+        if len(t) >= 2 and t not in STOPWORDS
+    ]
+
+
+def searchable_text(rec: dict) -> str:
+    """Concatenate a record's free-text fields into one searchable string."""
+    parts: list[str] = []
+    for field in SEARCHABLE_FIELDS:
+        value = rec.get(field) or []
+        if isinstance(value, list):
+            parts.extend(str(x) for x in value if x is not None)
+        elif isinstance(value, str):
+            parts.append(value)
+    notes = rec.get("notes")
+    if isinstance(notes, str):
+        parts.append(notes)
+    return " ".join(parts)
+
+
+def record_hash(rec: dict) -> str:
+    """Stable content hash over the fields that determine the embedding."""
+    canonical = json.dumps(
+        {"run_id": rec.get("run_id"), "text": searchable_text(rec)},
+        sort_keys=True, ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Keyword backend: TF-IDF + cosine
+# ---------------------------------------------------------------------------
+
+def _idf_map(doc_tokens: list[list[str]]) -> dict[str, float]:
+    """Smoothed inverse document frequency over the candidate corpus."""
+    n = len(doc_tokens)
+    df: Counter = Counter()
+    for toks in doc_tokens:
+        for term in set(toks):
+            df[term] += 1
+    return {term: math.log((n + 1) / (c + 1)) + 1.0 for term, c in df.items()}
+
+
+def _tfidf_vector(tokens: list[str], idf: dict[str, float]) -> dict[str, float]:
+    tf: Counter = Counter(tokens)
+    return {term: count * idf.get(term, 0.0) for term, count in tf.items()}
+
+
+def _cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    # Iterate the smaller vector for the dot product.
+    if len(a) > len(b):
+        a, b = b, a
+    dot = sum(weight * b.get(term, 0.0) for term, weight in a.items())
+    if dot == 0.0:
+        return 0.0
+    na = math.sqrt(sum(w * w for w in a.values()))
+    nb = math.sqrt(sum(w * w for w in b.values()))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _keyword_rank(query_tokens: list[str], candidates: list[dict]) -> list[tuple[dict, float, list[str]]]:
+    """Return (record, score, matched_terms) for candidates with score > 0."""
+    doc_tokens = [tokenize(searchable_text(rec)) for rec in candidates]
+    idf = _idf_map(doc_tokens)
+    q_vec = _tfidf_vector(query_tokens, idf)
+    q_set = set(query_tokens)
+
+    scored: list[tuple[dict, float, list[str]]] = []
+    for rec, toks in zip(candidates, doc_tokens):
+        score = _cosine(q_vec, _tfidf_vector(toks, idf))
+        if score <= 0.0:
+            continue
+        matched = sorted(q_set & set(toks), key=lambda t: -idf.get(t, 0.0))[:6]
+        scored.append((rec, score, matched))
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Optional embedding backend (dormant by default — stdlib-only repo)
+# ---------------------------------------------------------------------------
+
+class EmbeddingBackend:
+    """Pluggable semantic backend.
+
+    The base class is intentionally never available: this repo is stdlib-only,
+    so semantic ranking stays off until a deployment supplies a real backend by
+    overriding :func:`get_embedding_backend` (or monkeypatching it in tests).
+    Subclasses set ``model``/``dim`` and implement :meth:`embed`.
+    """
+
+    name = "embedding"
+    model = "none"
+    dim = 0
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+
+def get_embedding_backend() -> EmbeddingBackend | None:
+    """Return an available embedding backend, or ``None``.
+
+    Default: ``None`` (no embedding library wired in). Override this function or
+    monkeypatch it to enable the semantic path once records accumulate.
+    """
+    return None
+
+
+def _select_backend(backend: str, record_count: int, threshold: int,
+                    available: bool) -> tuple[str, str | None]:
+    """Resolve the effective backend and a fallback reason (or None).
+
+    Returns one of ``("keyword"|"embedding", reason)``. ``reason`` is non-None
+    only when an embedding request/auto-selection degraded to keyword.
+    """
+    if backend == "keyword":
+        return "keyword", None
+
+    eligible = available and record_count >= threshold
+    if eligible:
+        return "embedding", None
+
+    if not available:
+        reason = "embedding backend unavailable; using keyword"
+    else:
+        reason = f"record_count {record_count} < threshold {threshold}"
+    return "keyword", reason
+
+
+# ---------------------------------------------------------------------------
+# Embedding cache (stdlib sqlite3, keyed by content hash)
+# ---------------------------------------------------------------------------
+
+def _connect_cache(cache_path: Path):
+    import sqlite3
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(cache_path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS embeddings ("
+        "record_hash TEXT PRIMARY KEY, model TEXT, dim INTEGER, "
+        "vector BLOB, created_at TEXT)")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    return conn
+
+
+def _vec_to_blob(vec: list[float]) -> bytes:
+    return array("f", vec).tobytes()
+
+
+def _blob_to_vec(blob: bytes) -> list[float]:
+    a = array("f")
+    a.frombytes(blob)
+    return list(a)
+
+
+def _build_embeddings(records: list[dict], backend: EmbeddingBackend,
+                      cache_path: Path, cache: bool = True) -> dict[str, list[float]]:
+    """Return ``{record_hash: vector}`` for ``records``, embedding only the
+    records whose hash is not already cached. Writes new vectors back."""
+    import datetime as _dt
+
+    hashes = [record_hash(rec) for rec in records]
+    result: dict[str, list[float]] = {}
+
+    conn = None
+    cached: dict[str, list[float]] = {}
+    if cache:
+        conn = _connect_cache(cache_path)
+        rows = conn.execute(
+            "SELECT record_hash, vector FROM embeddings WHERE model = ?",
+            (backend.model,)).fetchall()
+        cached = {h: _blob_to_vec(b) for h, b in rows}
+
+    missing = [(h, rec) for h, rec in zip(hashes, records) if h not in cached]
+    if missing:
+        vectors = backend.embed([searchable_text(rec) for _, rec in missing])
+        now = _dt.datetime.now(_dt.timezone.utc).isoformat()
+        for (h, _rec), vec in zip(missing, vectors):
+            cached[h] = list(vec)
+            if conn is not None:
+                conn.execute(
+                    "INSERT OR REPLACE INTO embeddings "
+                    "(record_hash, model, dim, vector, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (h, backend.model, len(vec), _vec_to_blob(vec), now))
+        if conn is not None:
+            conn.commit()
+
+    for h in hashes:
+        if h in cached:
+            result[h] = cached[h]
+    if conn is not None:
+        conn.close()
+    return result
+
+
+def _embedding_rank(query_text: str, candidates: list[dict],
+                    backend: EmbeddingBackend, cache_path: Path,
+                    cache: bool) -> list[tuple[dict, float, list[str]]]:
+    vecs = _build_embeddings(candidates, backend, cache_path, cache=cache)
+    q_vec = backend.embed([query_text])[0]
+    q_tokens = set(tokenize(query_text))
+
+    def _cos(u: list[float], v: list[float]) -> float:
+        dot = sum(x * y for x, y in zip(u, v))
+        nu = math.sqrt(sum(x * x for x in u))
+        nv = math.sqrt(sum(y * y for y in v))
+        if nu == 0.0 or nv == 0.0:
+            return 0.0
+        return dot / (nu * nv)
+
+    scored: list[tuple[dict, float, list[str]]] = []
+    for rec in candidates:
+        vec = vecs.get(record_hash(rec))
+        if vec is None:
+            continue
+        score = _cos(q_vec, vec)
+        # matched_terms stays lexical for explainability even on the semantic path
+        matched = sorted(q_tokens & set(tokenize(searchable_text(rec))))[:6]
+        scored.append((rec, score, matched))
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _apply_filters(records: list[dict], filters: dict | None) -> tuple[list[dict], dict]:
+    applied: dict = {}
+    out = records
+    if not filters:
+        return out, applied
+    if filters.get("design_name"):
+        out = filter_by_design(out, filters["design_name"])
+        applied["design_name"] = filters["design_name"]
+    if filters.get("pdk"):
+        out = filter_by_pdk(out, filters["pdk"])
+        applied["pdk"] = filters["pdk"]
+    if filters.get("tool_used"):
+        out = filter_by_tool(out, filters["tool_used"])
+        applied["tool_used"] = filters["tool_used"]
+    return out, applied
+
+
+def _result_record(rec: dict, score: float, matched: list[str]) -> dict:
+    return {
+        "score": round(score, 4),
+        "matched_terms": matched,
+        "run_id": rec.get("run_id"),
+        "timestamp": rec.get("timestamp"),
+        "design_name": rec.get("design_name"),
+        "pdk": rec.get("pdk"),
+        "tool_used": rec.get("tool_used"),
+        "key_metrics": rec.get("key_metrics") or {},
+        "issues_encountered": rec.get("issues_encountered") or [],
+        "fixes_applied": rec.get("fixes_applied") or [],
+        "notes": rec.get("notes"),
+    }
+
+
+def query_experiences(
+    domain: str,
+    query_text: str,
+    *,
+    filters: dict | None = None,
+    limit: int = 5,
+    min_records_threshold: int = 50,
+    memory_root: Path | None = None,
+    backend: str = "auto",
+    cache: bool = True,
+) -> dict:
+    """Rank experience records for ``domain`` by relevance to ``query_text``.
+
+    See module docstring for the JSON shape returned.
+    """
+    if memory_root is None:
+        root = resolve_memory_root(None)
+    else:
+        root = Path(memory_root).expanduser()
+
+    jsonl = root / domain / "experiences.jsonl"
+    records = load_records(jsonl)
+    record_count = len(records)
+
+    candidates, filters_applied = _apply_filters(records, filters)
+
+    emb = get_embedding_backend()
+    resolved, fallback_reason = _select_backend(
+        backend, record_count, min_records_threshold, emb is not None)
+
+    query_tokens = tokenize(query_text)
+
+    if resolved == "embedding" and emb is not None:
+        cache_path = root / domain / INDEX_FILENAME
+        scored = _embedding_rank(query_text, candidates, emb, cache_path, cache)
+    else:
+        scored = _keyword_rank(query_tokens, candidates)
+
+    # Sort by score desc, tie-break newest timestamp first.
+    scored.sort(key=lambda t: (t[1], t[0].get("timestamp") or ""), reverse=True)
+    results = [_result_record(rec, score, matched)
+               for rec, score, matched in scored[:limit]]
+
+    return {
+        "domain": domain,
+        "query": query_text,
+        "record_count": record_count,
+        "threshold": min_records_threshold,
+        "backend": resolved,
+        "fell_back": resolved == "keyword" and backend != "keyword",
+        "fallback_reason": fallback_reason,
+        "filters_applied": filters_applied,
+        "candidates_after_filter": len(candidates),
+        "results": results,
+    }
+
+
+def reindex(domain: str, *, memory_root: Path | None = None,
+            cache: bool = True) -> dict:
+    """Rebuild the embedding cache for ``domain``.
+
+    Embeds any records whose hash is not cached and drops cache rows whose hash
+    no longer corresponds to a current record. No-op (no cache file created)
+    when no embedding backend is available.
+    """
+    if memory_root is None:
+        root = resolve_memory_root(None)
+    else:
+        root = Path(memory_root).expanduser()
+
+    jsonl = root / domain / "experiences.jsonl"
+    records = load_records(jsonl)
+
+    emb = get_embedding_backend()
+    if emb is None:
+        return {
+            "domain": domain,
+            "backend": "keyword",
+            "reindexed": False,
+            "reason": "no embedding backend available; keyword search needs no index",
+            "total": len(records),
+        }
+
+    cache_path = root / domain / INDEX_FILENAME
+    current_hashes = {record_hash(rec) for rec in records}
+
+    conn = _connect_cache(cache_path)
+    before = {h for (h,) in conn.execute(
+        "SELECT record_hash FROM embeddings WHERE model = ?", (emb.model,))}
+    stale = before - current_hashes
+    for h in stale:
+        conn.execute(
+            "DELETE FROM embeddings WHERE record_hash = ? AND model = ?",
+            (h, emb.model))
+    conn.commit()
+    conn.close()
+
+    vecs = _build_embeddings(records, emb, cache_path, cache=cache)
+    embedded = len(current_hashes - before)
+    return {
+        "domain": domain,
+        "backend": "embedding",
+        "model": emb.model,
+        "reindexed": True,
+        "embedded": embedded,
+        "reused": len(vecs) - embedded,
+        "removed": len(stale),
+        "total": len(records),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _print_table(result: dict) -> None:
+    backend = result["backend"]
+    tag = backend.upper()
+    if result["fell_back"]:
+        tag += f" (fell back: {result['fallback_reason']})"
+    print(f"# {result['domain']} — query: {result['query']!r}")
+    print(f"# backend={tag}  records={result['record_count']} "
+          f"candidates={result['candidates_after_filter']} "
+          f"threshold={result['threshold']}")
+    if result["filters_applied"]:
+        print(f"# filters: {result['filters_applied']}")
+    if not result["results"]:
+        print("# no matching records")
+        return
+    for i, r in enumerate(result["results"], 1):
+        print(f"\n[{i}] score={r['score']}  {r.get('design_name')}"
+              f"  pdk={r.get('pdk')}  tool={r.get('tool_used')}"
+              f"  ({r.get('timestamp')})")
+        if r["matched_terms"]:
+            print(f"    matched: {', '.join(r['matched_terms'])}")
+        for fix in r["fixes_applied"]:
+            print(f"    fix: {fix}")
+        if r.get("notes"):
+            print(f"    notes: {r['notes']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Semantic / keyword search over experience records")
+    parser.add_argument("--domain", required=True, choices=VALID_DOMAINS,
+                        help="Domain to search")
+    parser.add_argument("--query", default=None,
+                        help="Natural-language query (required unless --reindex)")
+    parser.add_argument("--design", default=None, help="Filter by design_name")
+    parser.add_argument("--pdk", default=None, help="Filter by pdk")
+    parser.add_argument("--tool", default=None, help="Filter by tool_used")
+    parser.add_argument("--limit", type=int, default=5, help="Max results")
+    parser.add_argument("--min-records", type=int, default=50,
+                        help="Embedding threshold (default: 50)")
+    parser.add_argument("--backend", choices=["auto", "keyword", "embedding"],
+                        default="auto", help="Backend selection")
+    parser.add_argument("--memory-root", default=None,
+                        help="Path to the memory/ directory")
+    parser.add_argument("--reindex", action="store_true",
+                        help="Rebuild the embedding cache, then exit")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    # Bad explicit memory root → exit 2 (mirrors qor_trends.py).
+    if args.memory_root and not Path(args.memory_root).expanduser().is_dir():
+        print(f"error: memory root not found: {args.memory_root}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.reindex:
+            summary = reindex(args.domain, memory_root=args.memory_root)
+            print(json.dumps(summary, indent=2))
+            return 0
+
+        if not args.query:
+            print("error: --query is required (or use --reindex)", file=sys.stderr)
+            return 2
+
+        filters = {
+            "design_name": args.design,
+            "pdk": args.pdk,
+            "tool_used": args.tool,
+        }
+        result = query_experiences(
+            args.domain, args.query,
+            filters=filters, limit=args.limit,
+            min_records_threshold=args.min_records,
+            memory_root=args.memory_root, backend=args.backend,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as exit-2 per CLI contract
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        _print_table(result)
+
+    return 0 if result["results"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 📌 Description
Implements FUTURE_WORK item 2: a semantic/keyword search system for experience records that lets orchestrators retrieve prior fixes by relevance to natural-language queries (e.g., "what fixed WNS issues on sky130 before?") instead of reading the entire JSONL file.

The implementation ships with a stable, dual-backend architecture:
- **Keyword backend** (default, always available): pure-stdlib TF-IDF + cosine ranker over free-text fields
- **Embedding backend** (optional, pluggable): semantic ranking via external library, with incremental sqlite3 caching

Both backends share an identical JSON output contract, so the keyword path is a drop-in fallback when records are sparse or no embedding library is available.

## 🔗 Related Issue
Closes FUTURE_WORK item 2 (phased implementation)

## 🧪 Type of Change
- [x] New feature
- [x] Scripts / tooling
- [x] Documentation update

## 🧠 What Changed?

### Core Library & CLI
- **`tools/experience_search.py`** (588 lines): 
  - Tokenizer that preserves EDA-friendly tokens (e.g., `wns_ns`, `sky130`, `-flatten`) while filtering stopwords
  - TF-IDF + cosine similarity ranker (keyword backend)
  - Pluggable `EmbeddingBackend` class for semantic ranking (dormant by default, stdlib-only repo)
  - Incremental sqlite3 embedding cache keyed by content hash
  - Unified `query_experiences()` API and `reindex()` for cache maintenance
  - Standalone CLI with `--domain`, `--query`, `--backend`, `--limit`, filtering, and `--reindex` modes
  - Automatic fallback to keyword when embedding unavailable or record count below threshold (default 50)

### MCP Server
- **`plugins/infrastructure/tools/mcp-memory.py`** (215 lines):
  - MCP 2024-11-05 stdio server exposing `query_experiences` tool
  - Mirrors protocol scaffolding of `mcp-adapter.py`
  - Imports `experience_search.py` in-process (no subprocess overhead)
  - Handles `initialize`, `ping`, `tools/list`, `tools/call` methods

### MCP Configuration
- **`plugins/infrastructure/mcp/mcp-memory.json`**: Claude settings snippet for registering the memory server

### Tests
- **`tests/test_experience_search.py`** (265 lines):
  - Tokenization, searchable text extraction, record hashing
  - Keyword ranking with TF-IDF and cosine similarity
  - Backend selection logic and fallback thresholds
  - Embedding cache incrementality and stale-hash cleanup (with stub backend)
  - CLI JSON output shape validation
  
- **`tests/test_mcp_memory.py`** (96 lines):
  - MCP protocol smoke tests: `initialize`, `tools/list`, `tools/call`
  - Error handling for unknown methods/tools and malformed arguments

### Documentation
- **`memory/README.md`**: New "Semantic / Keyword Experience Search" section with usage examples
- **`FUTURE_WORK.md`**: Marked item 2 as ✓ IMPLEMENTED (phased)
- **`CHANGELOG.md`**: Added unreleased entry documenting the feature
- **All orchestrator agent prompts** (11 files): Added optional guidance to query experiences before stage decisions

## 🔄 Affected Areas
- [x] Scripts / tooling
- [x] Documentation
- [x] MCP server infrastructure

## ⚙️ How to Test

1. **Keyword search (works today, any dataset size)**:
   ```bash
   python3 tools/experience_search.py --domain synthesis \
     --query "what fixed WNS on sky130" --pdk sky130
   ```

2. **Machine-readable JSON output**:
   ```bash
   python3 tools/experience_search.py --domain synthesis \
     --query "

https://claude.ai/code/session_01QEGpEnhik58a23MhK7Nj8J